### PR TITLE
Map reset

### DIFF
--- a/PennyMe/AppDelegate.swift
+++ b/PennyMe/AppDelegate.swift
@@ -7,20 +7,17 @@
 //
 
 import UIKit
-import MapKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDelegate {
-    
+
     var window: UIWindow?
-    var mapView: MKMapView?
-    
-    
+
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         application.registerUserNotificationSettings(UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil))
         UNUserNotificationCenter.current().delegate = self
-    
         
         return true
     }
@@ -34,19 +31,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-        // Save the current map region
-        print("STARTING TO SAVE")
-        print(mapView)
-        guard let mapView = mapView else { return }
-        let mapRegion = mapView.region
-
-        let defaults = UserDefaults.standard
-        defaults.set(mapRegion.center.latitude, forKey: "mapCenterLatitude")
-        defaults.set(mapRegion.center.longitude, forKey: "mapCenterLongitude")
-        defaults.set(mapRegion.span.latitudeDelta, forKey: "mapSpanLatitude")
-        defaults.set(mapRegion.span.longitudeDelta, forKey: "mapSpanLongitude")
-        print("SAVED")
-
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {

--- a/PennyMe/AppDelegate.swift
+++ b/PennyMe/AppDelegate.swift
@@ -7,17 +7,20 @@
 //
 
 import UIKit
+import MapKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDelegate {
-
+    
     var window: UIWindow?
-
-
+    var mapView: MKMapView?
+    
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         application.registerUserNotificationSettings(UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil))
         UNUserNotificationCenter.current().delegate = self
+    
         
         return true
     }
@@ -31,6 +34,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate,UNUserNotificationCenterDe
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+        // Save the current map region
+        print("STARTING TO SAVE")
+        print(mapView)
+        guard let mapView = mapView else { return }
+        let mapRegion = mapView.region
+
+        let defaults = UserDefaults.standard
+        defaults.set(mapRegion.center.latitude, forKey: "mapCenterLatitude")
+        defaults.set(mapRegion.center.longitude, forKey: "mapCenterLongitude")
+        defaults.set(mapRegion.span.latitudeDelta, forKey: "mapSpanLatitude")
+        defaults.set(mapRegion.span.longitudeDelta, forKey: "mapSpanLongitude")
+        print("SAVED")
+
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -15,10 +15,15 @@ let locationManager = CLLocationManager()
 let LAT_DEGREE_TO_KM = 110.948
 let closeNotifyDist = 0.3 // in km, send "you are very close" at this distance
 var radius = 20.0
+let defaults = UserDefaults.standard
+
+protocol MapViewProvider: AnyObject {
+    func getMapView() -> MKMapView?
+}
 
 @available(iOS 13.0, *)
-class ViewController: UIViewController, UITextFieldDelegate {
-
+class ViewController: UIViewController, UITextFieldDelegate, MapViewProvider {
+    
     @IBOutlet weak var PennyMap: MKMapView!
     @IBOutlet weak var ownLocation: UIButton!
     @IBOutlet var toggleMapButton: UIButton!
@@ -53,8 +58,12 @@ class ViewController: UIViewController, UITextFieldDelegate {
     var currMap = 1
     let satelliteButton = UIButton(frame: CGRect(x: 10, y: 510, width: 50, height: 50))
     @IBOutlet weak var mapType : UISegmentedControl!
-
-
+    
+    // Implement the getMapView function to return the mapView instance
+    func getMapView() -> MKMapView? {
+        return PennyMap
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         overrideUserInterfaceStyle = .light
@@ -108,6 +117,19 @@ class ViewController: UIViewController, UITextFieldDelegate {
         super.viewWillAppear(animated)
         // each time the view appears, check colours of the pins
         check_json_dict()
+        
+//        print("=============RESTORING VIEW============")
+//        // Load the saved map region
+//        let centerLatitude = defaults.double(forKey: "mapCenterLatitude")
+//        let centerLongitude = defaults.double(forKey: "mapCenterLongitude")
+//        let spanLatitude = defaults.double(forKey: "mapSpanLatitude")
+//        let spanLongitude = defaults.double(forKey: "mapSpanLongitude")
+//
+//        let center = CLLocationCoordinate2D(latitude: centerLatitude, longitude: centerLongitude)
+//        let span = MKCoordinateSpan(latitudeDelta: spanLatitude, longitudeDelta: spanLongitude)
+//
+//        let savedRegion = MKCoordinateRegion(center: center, span: span)
+//        PennyMap.setRegion(savedRegion, animated: false)
     }
     
     func setDelegates(){
@@ -137,7 +159,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
         ownLocation.layer.shadowRadius = 0.0
         ownLocation.layer.masksToBounds = false
         
-        PennyMap.addSubview(ownLocation)
+//        PennyMap.addSubview(ownLocation)
     }
     
     func addSettingsButton(){
@@ -247,7 +269,6 @@ class ViewController: UIViewController, UITextFieldDelegate {
     }
     
     func check_json_dict(){
-//        print("checking json dictionary")
         // initialize empty status dictionary
         var statusDict = [[String: String]()]
         //variable indicating whether we load something
@@ -435,6 +456,7 @@ extension ViewController: MKMapViewDelegate {
             self.performSegue(withIdentifier: "ShowPinViewController", sender: nil)
         }
     }
+
 }
 
 
@@ -484,6 +506,14 @@ extension ViewController: CLLocationManagerDelegate {
             longitudinalMeters: regionInMeters
         )
         PennyMap.setRegion(region, animated: true)
+
+//        let mapRegion = PennyMap.region
+//        defaults.set(mapRegion.center.latitude, forKey: "mapCenterLatitude")
+//        defaults.set(mapRegion.center.longitude, forKey: "mapCenterLongitude")
+//        defaults.set(mapRegion.span.latitudeDelta, forKey: "mapSpanLatitude")
+//        defaults.set(mapRegion.span.longitudeDelta, forKey: "mapSpanLongitude")
+//        print("=========SAVING VIEW locationManager=======")
+        
     }
     
     // Send user a local notification if they have the app running in the bg
@@ -688,6 +718,15 @@ extension ViewController: UITableViewDelegate, UITableViewDataSource {
         tableShown = false
         searchController.searchBar.text = ""
         
+//        // Save view
+//        let mapRegion = PennyMap.region
+//
+//        defaults.set(mapRegion.center.latitude, forKey: "mapCenterLatitude")
+//        defaults.set(mapRegion.center.longitude, forKey: "mapCenterLongitude")
+//        defaults.set(mapRegion.span.latitudeDelta, forKey: "mapSpanLatitude")
+//        defaults.set(mapRegion.span.longitudeDelta, forKey: "mapSpanLongitude")
+//        print("=========SAVING VIEW tableView=======")
+        
         self.performSegue(withIdentifier: "ShowPinViewController", sender: self)
     }
 }
@@ -722,3 +761,5 @@ extension UISearchBar {
         }
     }
 }
+
+

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -247,7 +247,6 @@ class ViewController: UIViewController, UITextFieldDelegate {
     }
     
     func check_json_dict(){
-//        print("checking json dictionary")
         // initialize empty status dictionary
         var statusDict = [[String: String]()]
         //variable indicating whether we load something
@@ -473,17 +472,6 @@ extension ViewController: CLLocationManagerDelegate {
             // this is to prevent that the "nearby" notification is sent only once (per location)
             lastClosestID = closestID
         }
-        // Below code only executes if locations.last exists
-        let center = CLLocationCoordinate2D(
-            latitude: location.coordinate.latitude,
-            longitude: location.coordinate.longitude
-        )
-        let region = MKCoordinateRegion(
-            center: center,
-            latitudinalMeters: regionInMeters,
-            longitudinalMeters: regionInMeters
-        )
-        PennyMap.setRegion(region, animated: true)
     }
     
     // Send user a local notification if they have the app running in the bg

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -15,15 +15,10 @@ let locationManager = CLLocationManager()
 let LAT_DEGREE_TO_KM = 110.948
 let closeNotifyDist = 0.3 // in km, send "you are very close" at this distance
 var radius = 20.0
-let defaults = UserDefaults.standard
-
-protocol MapViewProvider: AnyObject {
-    func getMapView() -> MKMapView?
-}
 
 @available(iOS 13.0, *)
-class ViewController: UIViewController, UITextFieldDelegate, MapViewProvider {
-    
+class ViewController: UIViewController, UITextFieldDelegate {
+
     @IBOutlet weak var PennyMap: MKMapView!
     @IBOutlet weak var ownLocation: UIButton!
     @IBOutlet var toggleMapButton: UIButton!
@@ -58,12 +53,8 @@ class ViewController: UIViewController, UITextFieldDelegate, MapViewProvider {
     var currMap = 1
     let satelliteButton = UIButton(frame: CGRect(x: 10, y: 510, width: 50, height: 50))
     @IBOutlet weak var mapType : UISegmentedControl!
-    
-    // Implement the getMapView function to return the mapView instance
-    func getMapView() -> MKMapView? {
-        return PennyMap
-    }
-    
+
+
     override func viewDidLoad() {
         super.viewDidLoad()
         overrideUserInterfaceStyle = .light
@@ -117,19 +108,6 @@ class ViewController: UIViewController, UITextFieldDelegate, MapViewProvider {
         super.viewWillAppear(animated)
         // each time the view appears, check colours of the pins
         check_json_dict()
-        
-//        print("=============RESTORING VIEW============")
-//        // Load the saved map region
-//        let centerLatitude = defaults.double(forKey: "mapCenterLatitude")
-//        let centerLongitude = defaults.double(forKey: "mapCenterLongitude")
-//        let spanLatitude = defaults.double(forKey: "mapSpanLatitude")
-//        let spanLongitude = defaults.double(forKey: "mapSpanLongitude")
-//
-//        let center = CLLocationCoordinate2D(latitude: centerLatitude, longitude: centerLongitude)
-//        let span = MKCoordinateSpan(latitudeDelta: spanLatitude, longitudeDelta: spanLongitude)
-//
-//        let savedRegion = MKCoordinateRegion(center: center, span: span)
-//        PennyMap.setRegion(savedRegion, animated: false)
     }
     
     func setDelegates(){
@@ -159,7 +137,7 @@ class ViewController: UIViewController, UITextFieldDelegate, MapViewProvider {
         ownLocation.layer.shadowRadius = 0.0
         ownLocation.layer.masksToBounds = false
         
-//        PennyMap.addSubview(ownLocation)
+        PennyMap.addSubview(ownLocation)
     }
     
     func addSettingsButton(){
@@ -269,6 +247,7 @@ class ViewController: UIViewController, UITextFieldDelegate, MapViewProvider {
     }
     
     func check_json_dict(){
+//        print("checking json dictionary")
         // initialize empty status dictionary
         var statusDict = [[String: String]()]
         //variable indicating whether we load something
@@ -456,7 +435,6 @@ extension ViewController: MKMapViewDelegate {
             self.performSegue(withIdentifier: "ShowPinViewController", sender: nil)
         }
     }
-
 }
 
 
@@ -506,14 +484,6 @@ extension ViewController: CLLocationManagerDelegate {
             longitudinalMeters: regionInMeters
         )
         PennyMap.setRegion(region, animated: true)
-
-//        let mapRegion = PennyMap.region
-//        defaults.set(mapRegion.center.latitude, forKey: "mapCenterLatitude")
-//        defaults.set(mapRegion.center.longitude, forKey: "mapCenterLongitude")
-//        defaults.set(mapRegion.span.latitudeDelta, forKey: "mapSpanLatitude")
-//        defaults.set(mapRegion.span.longitudeDelta, forKey: "mapSpanLongitude")
-//        print("=========SAVING VIEW locationManager=======")
-        
     }
     
     // Send user a local notification if they have the app running in the bg
@@ -718,15 +688,6 @@ extension ViewController: UITableViewDelegate, UITableViewDataSource {
         tableShown = false
         searchController.searchBar.text = ""
         
-//        // Save view
-//        let mapRegion = PennyMap.region
-//
-//        defaults.set(mapRegion.center.latitude, forKey: "mapCenterLatitude")
-//        defaults.set(mapRegion.center.longitude, forKey: "mapCenterLongitude")
-//        defaults.set(mapRegion.span.latitudeDelta, forKey: "mapSpanLatitude")
-//        defaults.set(mapRegion.span.longitudeDelta, forKey: "mapSpanLongitude")
-//        print("=========SAVING VIEW tableView=======")
-        
         self.performSegue(withIdentifier: "ShowPinViewController", sender: self)
     }
 }
@@ -761,5 +722,3 @@ extension UISearchBar {
         }
     }
 }
-
-


### PR DESCRIPTION
Previously, the `locationManager` function which is responsible for the push notification, recentered the view on the current location. Since this was executed whenever the app was re-opened (at least when a possible change of location was noticed (this is why this problem occurred only in the app, not in the simulator)), this effectively centered the view to the current location **whenever the app was (re)opened**.

--> Removed those lines