### PR TITLE
Improve Map pin view settings

### DIFF
--- a/PennyMe.xcodeproj/project.pbxproj
+++ b/PennyMe.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9F421AB3261B9755004197B4 /* ArtworkViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F421AB2261B9755004197B4 /* ArtworkViews.swift */; };
 		9F612054230CAC2300F1D9DE /* Artwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F612053230CAC2300F1D9DE /* Artwork.swift */; };
 		9F70CCEA231850DC003AED89 /* all_locations.json in Resources */ = {isa = PBXBuildFile; fileRef = 9F70CCE9231850DC003AED89 /* all_locations.json */; };
+		9F9C64A52A10D12E00C57887 /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9C64A42A10D12E00C57887 /* VersionManager.swift */; };
 		9F9F31A52300B40900C0E854 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9F31A42300B40900C0E854 /* AppDelegate.swift */; };
 		9F9F31A72300B40900C0E854 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9F31A62300B40900C0E854 /* ViewController.swift */; };
 		9F9F31AA2300B40900C0E854 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F9F31A82300B40900C0E854 /* Main.storyboard */; };
@@ -48,6 +49,7 @@
 		9F421AB2261B9755004197B4 /* ArtworkViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtworkViews.swift; sourceTree = "<group>"; };
 		9F612053230CAC2300F1D9DE /* Artwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artwork.swift; sourceTree = "<group>"; };
 		9F70CCE9231850DC003AED89 /* all_locations.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = all_locations.json; path = data/all_locations.json; sourceTree = "<group>"; };
+		9F9C64A42A10D12E00C57887 /* VersionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionManager.swift; sourceTree = "<group>"; };
 		9F9F31A12300B40900C0E854 /* PennyMe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PennyMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F9F31A42300B40900C0E854 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9F9F31A62300B40900C0E854 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 				9F9F31B02300B40A00C0E854 /* Info.plist */,
 				9F421AB2261B9755004197B4 /* ArtworkViews.swift */,
 				9FF43BD92621221A00BE3F6A /* SearchFooter.swift */,
+				9F9C64A42A10D12E00C57887 /* VersionManager.swift */,
 			);
 			path = PennyMe;
 			sourceTree = "<group>";
@@ -296,6 +299,7 @@
 			files = (
 				9F9F31A72300B40900C0E854 /* ViewController.swift in Sources */,
 				8319D8D027414AC100E97D93 /* ZoomViewController.swift in Sources */,
+				9F9C64A52A10D12E00C57887 /* VersionManager.swift in Sources */,
 				9F421AB3261B9755004197B4 /* ArtworkViews.swift in Sources */,
 				83D226CD2620F4910050ED9E /* PinViewController.swift in Sources */,
 				9F612054230CAC2300F1D9DE /* Artwork.swift in Sources */,

--- a/PennyMe.xcodeproj/project.pbxproj
+++ b/PennyMe.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "PennyMe--com.de.pennyme";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
@@ -509,7 +509,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "PennyMe--com.de.pennyme";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;

--- a/PennyMe/AboutViewController.swift
+++ b/PennyMe/AboutViewController.swift
@@ -12,7 +12,7 @@ class AboutViewController: UIViewController {
 
     
     @IBOutlet weak var label: UILabel!
-    
+    private let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     override func viewDidLoad() {
         super.viewDidLoad()
         if #available(iOS 13.0, *) {
@@ -22,7 +22,7 @@ class AboutViewController: UIViewController {
         self.label.contentMode = .scaleToFill
         self.label.numberOfLines = 30
 
-        self.label.text = "PennyMe makes collecting pennys easier than ever before - anywhere you travel. \n\nYou can view locations of nearby penny machines and explore your favorite destinations. Change the status of the pins and turn PennyMe into your digital penny collection. PennyMe also helps you to navigate to the next machine and provides pictures and more information about each machine. To ease your life, PennyMe can also send you push notifications if you are nearby an unvisted penny machine.  Please help growing our database by sending pictures or information about machine and feel free to send us any feedback. \n\nThis is PennyMe V1.3.\n©Jannis Born & Nina Wiedemann (2023)"
+        self.label.text = "PennyMe makes collecting pennys easier than ever before - anywhere you travel. \n\nYou can view locations of nearby penny machines and explore your favorite destinations. Change the status of the pins and turn PennyMe into your digital penny collection. PennyMe also helps you to navigate to the next machine and provides pictures and more information about each machine. To ease your life, PennyMe can also send you push notifications if you are nearby an unvisted penny machine.  Please help growing our database by sending pictures or information about machine and feel free to send us any feedback. \n\nThis is PennyMe v\(currentVersion ?? "").\n©Jannis Born & Nina Wiedemann (2023)"
     }
 }
 

--- a/PennyMe/Artwork.swift
+++ b/PennyMe/Artwork.swift
@@ -55,10 +55,6 @@ class Artwork: NSObject, MKAnnotation {
         id = String((properties["id"] as? Int)!)
         coordinate = point.coordinate
         text = title! + locationName
-        if (status == "retired") &&
-            (UserDefaults.standard.bool(forKey: "retiredSwitch") == false) {
-            return nil
-        }
         
         super.init()
     }

--- a/PennyMe/Artwork.swift
+++ b/PennyMe/Artwork.swift
@@ -55,6 +55,10 @@ class Artwork: NSObject, MKAnnotation {
         id = String((properties["id"] as? Int)!)
         coordinate = point.coordinate
         text = title! + locationName
+        if (status == "retired") &&
+            (UserDefaults.standard.bool(forKey: "retiredSwitch") == false) {
+            return nil
+        }
         
         super.init()
     }

--- a/PennyMe/ArtworkViews.swift
+++ b/PennyMe/ArtworkViews.swift
@@ -19,6 +19,8 @@ class ArtworkMarkerView: MKMarkerAnnotationView {
       guard let artwork = newValue as? Artwork else {
         return
       }
+        clusterPins = UserDefaults.standard.bool(forKey: "clusterPinSwitch")
+        
         if !clusterPins {
             displayPriority = MKFeatureDisplayPriority.required
         }

--- a/PennyMe/ArtworkViews.swift
+++ b/PennyMe/ArtworkViews.swift
@@ -10,12 +10,19 @@ import Foundation
 import MapKit
 
 class ArtworkMarkerView: MKMarkerAnnotationView {
+
+  var clusterPins: Bool = true
   override var annotation: MKAnnotation? {
+
     willSet {
       // 1
       guard let artwork = newValue as? Artwork else {
         return
       }
+        if !clusterPins {
+            displayPriority = MKFeatureDisplayPriority.required
+        }
+
         // Set marker color
         markerTintColor = artwork.markerTintColor
         

--- a/PennyMe/Base.lproj/Main.storyboard
+++ b/PennyMe/Base.lproj/Main.storyboard
@@ -97,14 +97,14 @@
                             <tableViewSection id="YX1-ej-Yw9">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="tJV-zg-KYa">
-                                        <rect key="frame" x="0.0" y="18" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="18" width="375" height="43"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tJV-zg-KYa" id="cNb-TX-7RI">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b7j-4w-sXF">
-                                                    <rect key="frame" x="26" y="11" width="323" height="21.5"/>
+                                                    <rect key="frame" x="26" y="11" width="323" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -120,7 +120,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="fjs-hV-TPw">
-                                        <rect key="frame" x="0.0" y="61.5" width="375" height="210"/>
+                                        <rect key="frame" x="0.0" y="61" width="375" height="210"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fjs-hV-TPw" id="LOL-Ul-Er3">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="210"/>
@@ -146,7 +146,7 @@
                             <tableViewSection headerTitle="Status" footerTitle="Mark the penny machines you have alread visited or do not want to visit (&quot;marked&quot;), or machines that are out of order" id="1p5-KZ-43a">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="0Rf-TU-wLD">
-                                        <rect key="frame" x="0.0" y="335" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="334.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0Rf-TU-wLD" id="Uvs-MM-hr1">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -202,7 +202,7 @@
                             <tableViewSection id="Uy0-rC-cvY">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="nN5-QI-kia">
-                                        <rect key="frame" x="0.0" y="458.5" width="375" height="41"/>
+                                        <rect key="frame" x="0.0" y="458" width="375" height="41"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nN5-QI-kia" id="kbM-Er-FOS">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="41"/>
@@ -229,7 +229,7 @@
                             <tableViewSection headerTitle="Comments" id="AG4-72-6Vw">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Xfc-Oc-NxP">
-                                        <rect key="frame" x="0.0" y="555.5" width="375" height="43"/>
+                                        <rect key="frame" x="0.0" y="555" width="375" height="43"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xfc-Oc-NxP" id="OPC-2f-ym3">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
@@ -251,7 +251,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="N8K-xa-czH">
-                                        <rect key="frame" x="0.0" y="598.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="598" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="N8K-xa-czH" id="EbS-er-6Gh">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -277,7 +277,7 @@
                             <tableViewSection headerTitle="Further information" id="yoa-01-ZMn">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="wcD-oI-gR2">
-                                        <rect key="frame" x="0.0" y="698" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="697.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wcD-oI-gR2" id="mFT-jz-Gf6">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -302,7 +302,7 @@
                             <tableViewSection headerTitle="Contribute" footerTitle="Tell us if this machine has retired or if the address is not correct." id="wLy-lG-XH8">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="meO-D7-5e4">
-                                        <rect key="frame" x="0.0" y="805.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="805" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="meO-D7-5e4" id="GXP-u1-AO6">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -497,11 +497,11 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="CAj-Vo-gk3">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CAj-Vo-gk3">
                                                     <rect key="frame" x="312" y="6.5" width="51" height="31.5"/>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Show retired machines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ubP-gN-cmc">
-                                                    <rect key="frame" x="22" y="11" width="174" height="21.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Show unvisited machines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ubP-gN-cmc">
+                                                    <rect key="frame" x="22" y="11" width="192" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -518,34 +518,35 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="BXe-8T-MhT">
-                                        <rect key="frame" x="0.0" y="315" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="315" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BXe-8T-MhT" id="qtP-0C-juF">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iz0-us-CPB">
-                                                    <rect key="frame" x="312" y="6.5" width="51" height="31.5"/>
-                                                </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Show unvisited machines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KpS-Jq-930">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show visited machines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KpS-Jq-930">
                                                     <rect key="frame" x="23" y="11" width="192" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iz0-us-CPB">
+                                                    <rect key="frame" x="310" y="6" width="51" height="31.5"/>
+                                                </switch>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="KpS-Jq-930" firstAttribute="bottom" secondItem="qtP-0C-juF" secondAttribute="bottomMargin" id="4GS-90-XNq"/>
-                                                <constraint firstItem="KpS-Jq-930" firstAttribute="centerY" secondItem="iz0-us-CPB" secondAttribute="centerY" id="55X-hc-lDz"/>
-                                                <constraint firstItem="iz0-us-CPB" firstAttribute="top" secondItem="qtP-0C-juF" secondAttribute="topMargin" constant="-4.5" id="9O6-Gq-oWO"/>
-                                                <constraint firstItem="KpS-Jq-930" firstAttribute="top" secondItem="qtP-0C-juF" secondAttribute="topMargin" id="CL9-HW-ORp"/>
-                                                <constraint firstItem="KpS-Jq-930" firstAttribute="leading" secondItem="qtP-0C-juF" secondAttribute="leadingMargin" constant="7" id="SxO-5q-c57"/>
-                                                <constraint firstItem="iz0-us-CPB" firstAttribute="leading" secondItem="KpS-Jq-930" secondAttribute="trailing" constant="97" id="myD-2v-ODk"/>
+                                                <constraint firstItem="iz0-us-CPB" firstAttribute="leading" secondItem="KpS-Jq-930" secondAttribute="trailing" constant="95" id="NUB-0o-pm2"/>
+                                                <constraint firstItem="iz0-us-CPB" firstAttribute="trailing" secondItem="qtP-0C-juF" secondAttribute="trailingMargin" id="W1V-Dv-akY"/>
+                                                <constraint firstItem="KpS-Jq-930" firstAttribute="top" secondItem="qtP-0C-juF" secondAttribute="topMargin" id="aAr-cS-uQy"/>
+                                                <constraint firstItem="KpS-Jq-930" firstAttribute="centerY" secondItem="iz0-us-CPB" secondAttribute="centerY" id="fpn-0g-afR"/>
+                                                <constraint firstItem="KpS-Jq-930" firstAttribute="leading" secondItem="qtP-0C-juF" secondAttribute="leadingMargin" constant="7" id="omM-XD-OIh"/>
+                                                <constraint firstItem="KpS-Jq-930" firstAttribute="centerY" secondItem="qtP-0C-juF" secondAttribute="centerY" id="rgb-uU-jSU"/>
+                                                <constraint firstItem="iz0-us-CPB" firstAttribute="top" secondItem="qtP-0C-juF" secondAttribute="topMargin" constant="-5" id="zud-yf-SZG"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="r5f-be-tOv">
-                                        <rect key="frame" x="0.0" y="359.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="358.5" width="375" height="44.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r5f-be-tOv" id="NQ5-2Z-cdH">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
@@ -572,16 +573,16 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="i1i-Z0-x6u">
-                                        <rect key="frame" x="0.0" y="404" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="403" width="375" height="44.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i1i-Z0-x6u" id="6OQ-LK-des">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MFc-9U-CAg">
-                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="MFc-9U-CAg">
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31.5"/>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cluster pins" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bY9-1y-Dau">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show retired machines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bY9-1y-Dau">
                                                     <rect key="frame" x="21" y="11" width="270" height="22.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="270" id="LaU-oL-QFl"/>
@@ -601,12 +602,42 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="kgd-Nd-EFj">
+                                        <rect key="frame" x="0.0" y="447.5" width="375" height="44.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kgd-Nd-EFj" id="4Uk-yc-MBz">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7cL-Kf-aJt">
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31.5"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cluster pins" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Kx-sy-Z7f">
+                                                    <rect key="frame" x="21" y="11" width="270" height="22.5"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="270" id="2xD-zq-yDZ"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="7cL-Kf-aJt" firstAttribute="leading" secondItem="9Kx-sy-Z7f" secondAttribute="trailing" constant="19" id="0Vq-20-Hrg"/>
+                                                <constraint firstItem="7cL-Kf-aJt" firstAttribute="trailing" secondItem="4Uk-yc-MBz" secondAttribute="trailingMargin" id="6va-JG-AwM"/>
+                                                <constraint firstItem="9Kx-sy-Z7f" firstAttribute="top" secondItem="4Uk-yc-MBz" secondAttribute="topMargin" id="CTn-o2-kWe"/>
+                                                <constraint firstItem="9Kx-sy-Z7f" firstAttribute="centerY" secondItem="7cL-Kf-aJt" secondAttribute="centerY" id="a1a-so-9t3"/>
+                                                <constraint firstItem="9Kx-sy-Z7f" firstAttribute="bottom" secondItem="4Uk-yc-MBz" secondAttribute="bottomMargin" id="iwR-AF-mkF"/>
+                                                <constraint firstItem="7cL-Kf-aJt" firstAttribute="top" secondItem="4Uk-yc-MBz" secondAttribute="topMargin" constant="-4.5" id="zfr-FH-Rub"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection footerTitle="Tell us if a machine does not exist anymore or is located elsewhere" id="nTw-xt-hpl">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ymV-67-V8M">
-                                        <rect key="frame" x="0.0" y="484.5" width="375" height="45.5"/>
+                                        <rect key="frame" x="0.0" y="528" width="375" height="45.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ymV-67-V8M" id="BEC-Lw-vl6">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45.5"/>
@@ -639,12 +670,15 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Settings" id="zx6-GS-7GO"/>
                     <connections>
-                        <outlet property="clusterPinsSwitch" destination="MFc-9U-CAg" id="59N-Ri-Hyc"/>
+                        <outlet property="clusterPinsSwitch" destination="7cL-Kf-aJt" id="eS6-iC-1Ge"/>
+                        <outlet property="markedSwitch" destination="UsS-ph-Xcp" id="JYo-vU-XX3"/>
                         <outlet property="navigationbar" destination="zx6-GS-7GO" id="qrc-Ln-jyY"/>
                         <outlet property="pushSwitch" destination="IOA-uP-fPv" id="YhF-qT-r1e"/>
                         <outlet property="radiusSlider" destination="i4T-NX-O0k" id="RD6-uO-z5h"/>
                         <outlet property="reportProblemButton" destination="5ay-Q4-ROi" id="Pwg-G0-enY"/>
-                        <outlet property="retiredSwitch" destination="CAj-Vo-gk3" id="TDR-MO-yNc"/>
+                        <outlet property="retiredSwitch" destination="MFc-9U-CAg" id="Ny7-GM-2mh"/>
+                        <outlet property="unvisitedSwitch" destination="CAj-Vo-gk3" id="jDg-d5-fH4"/>
+                        <outlet property="visitedSwitch" destination="iz0-us-CPB" id="wj6-l3-Gcx"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tGJ-xH-scI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/PennyMe/Base.lproj/Main.storyboard
+++ b/PennyMe/Base.lproj/Main.storyboard
@@ -97,14 +97,14 @@
                             <tableViewSection id="YX1-ej-Yw9">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="tJV-zg-KYa">
-                                        <rect key="frame" x="0.0" y="18" width="375" height="43"/>
+                                        <rect key="frame" x="0.0" y="18" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tJV-zg-KYa" id="cNb-TX-7RI">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b7j-4w-sXF">
-                                                    <rect key="frame" x="26" y="11" width="323" height="21"/>
+                                                    <rect key="frame" x="26" y="11" width="323" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -120,7 +120,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="fjs-hV-TPw">
-                                        <rect key="frame" x="0.0" y="61" width="375" height="210"/>
+                                        <rect key="frame" x="0.0" y="61.5" width="375" height="210"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fjs-hV-TPw" id="LOL-Ul-Er3">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="210"/>
@@ -146,7 +146,7 @@
                             <tableViewSection headerTitle="Status" footerTitle="Mark the penny machines you have alread visited or do not want to visit (&quot;marked&quot;), or machines that are out of order" id="1p5-KZ-43a">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="0Rf-TU-wLD">
-                                        <rect key="frame" x="0.0" y="334.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="335" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0Rf-TU-wLD" id="Uvs-MM-hr1">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -202,7 +202,7 @@
                             <tableViewSection id="Uy0-rC-cvY">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="nN5-QI-kia">
-                                        <rect key="frame" x="0.0" y="458" width="375" height="41"/>
+                                        <rect key="frame" x="0.0" y="458.5" width="375" height="41"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nN5-QI-kia" id="kbM-Er-FOS">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="41"/>
@@ -229,14 +229,14 @@
                             <tableViewSection headerTitle="Comments" id="AG4-72-6Vw">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Xfc-Oc-NxP">
-                                        <rect key="frame" x="0.0" y="555" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="555.5" width="375" height="43"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xfc-Oc-NxP" id="OPC-2f-ym3">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No comments yet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c1X-rg-nvf">
-                                                    <rect key="frame" x="16" y="11" width="343" height="21.5"/>
+                                                    <rect key="frame" x="16" y="11" width="343" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -488,10 +488,125 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="Map settings" id="tQk-an-GrX">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="vtn-yQ-Q6X">
+                                        <rect key="frame" x="0.0" y="270.5" width="375" height="44.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vtn-yQ-Q6X" id="scV-OZ-DAf">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="CAj-Vo-gk3">
+                                                    <rect key="frame" x="312" y="6.5" width="51" height="31.5"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Show retired machines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ubP-gN-cmc">
+                                                    <rect key="frame" x="22" y="11" width="174" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="ubP-gN-cmc" firstAttribute="bottom" secondItem="scV-OZ-DAf" secondAttribute="bottomMargin" id="A1F-9F-dVF"/>
+                                                <constraint firstItem="ubP-gN-cmc" firstAttribute="leading" secondItem="scV-OZ-DAf" secondAttribute="leadingMargin" constant="6" id="GVu-Rc-ZTQ"/>
+                                                <constraint firstItem="ubP-gN-cmc" firstAttribute="top" secondItem="scV-OZ-DAf" secondAttribute="topMargin" id="a6f-Wp-0Wj"/>
+                                                <constraint firstItem="ubP-gN-cmc" firstAttribute="centerY" secondItem="CAj-Vo-gk3" secondAttribute="centerY" id="dKU-7B-2EO"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="CAj-Vo-gk3" secondAttribute="trailing" constant="-2" id="kfT-vw-aX9"/>
+                                                <constraint firstItem="CAj-Vo-gk3" firstAttribute="top" secondItem="scV-OZ-DAf" secondAttribute="topMargin" constant="-4.5" id="z9z-kr-yG6"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="BXe-8T-MhT">
+                                        <rect key="frame" x="0.0" y="315" width="375" height="44.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BXe-8T-MhT" id="qtP-0C-juF">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iz0-us-CPB">
+                                                    <rect key="frame" x="312" y="6.5" width="51" height="31.5"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Show unvisited machines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KpS-Jq-930">
+                                                    <rect key="frame" x="23" y="11" width="192" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="KpS-Jq-930" firstAttribute="bottom" secondItem="qtP-0C-juF" secondAttribute="bottomMargin" id="4GS-90-XNq"/>
+                                                <constraint firstItem="KpS-Jq-930" firstAttribute="centerY" secondItem="iz0-us-CPB" secondAttribute="centerY" id="55X-hc-lDz"/>
+                                                <constraint firstItem="iz0-us-CPB" firstAttribute="top" secondItem="qtP-0C-juF" secondAttribute="topMargin" constant="-4.5" id="9O6-Gq-oWO"/>
+                                                <constraint firstItem="KpS-Jq-930" firstAttribute="top" secondItem="qtP-0C-juF" secondAttribute="topMargin" id="CL9-HW-ORp"/>
+                                                <constraint firstItem="KpS-Jq-930" firstAttribute="leading" secondItem="qtP-0C-juF" secondAttribute="leadingMargin" constant="7" id="SxO-5q-c57"/>
+                                                <constraint firstItem="iz0-us-CPB" firstAttribute="leading" secondItem="KpS-Jq-930" secondAttribute="trailing" constant="97" id="myD-2v-ODk"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="r5f-be-tOv">
+                                        <rect key="frame" x="0.0" y="359.5" width="375" height="44.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r5f-be-tOv" id="NQ5-2Z-cdH">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UsS-ph-Xcp">
+                                                    <rect key="frame" x="311" y="6.5" width="51" height="31.5"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Show marked machines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2V4-tQ-sTr">
+                                                    <rect key="frame" x="23" y="11" width="181" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="UsS-ph-Xcp" secondAttribute="trailing" constant="-1" id="0CB-M6-ky3"/>
+                                                <constraint firstItem="2V4-tQ-sTr" firstAttribute="bottom" secondItem="NQ5-2Z-cdH" secondAttribute="bottomMargin" id="E2n-Fk-l3z"/>
+                                                <constraint firstItem="2V4-tQ-sTr" firstAttribute="top" secondItem="NQ5-2Z-cdH" secondAttribute="topMargin" id="GvR-m2-b2X"/>
+                                                <constraint firstItem="2V4-tQ-sTr" firstAttribute="centerY" secondItem="UsS-ph-Xcp" secondAttribute="centerY" id="HK4-A5-FXe"/>
+                                                <constraint firstItem="UsS-ph-Xcp" firstAttribute="top" secondItem="NQ5-2Z-cdH" secondAttribute="topMargin" constant="-4.5" id="ac0-3o-8Yx"/>
+                                                <constraint firstItem="2V4-tQ-sTr" firstAttribute="leading" secondItem="NQ5-2Z-cdH" secondAttribute="leadingMargin" constant="7" id="vLS-kG-kg1"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="i1i-Z0-x6u">
+                                        <rect key="frame" x="0.0" y="404" width="375" height="44.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i1i-Z0-x6u" id="6OQ-LK-des">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MFc-9U-CAg">
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cluster pins" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bY9-1y-Dau">
+                                                    <rect key="frame" x="21" y="11" width="270" height="22.5"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="270" id="LaU-oL-QFl"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="MFc-9U-CAg" firstAttribute="leading" secondItem="bY9-1y-Dau" secondAttribute="trailing" constant="19" id="KBC-N6-c76"/>
+                                                <constraint firstItem="bY9-1y-Dau" firstAttribute="centerY" secondItem="MFc-9U-CAg" secondAttribute="centerY" id="SU7-m1-9x4"/>
+                                                <constraint firstItem="bY9-1y-Dau" firstAttribute="top" secondItem="6OQ-LK-des" secondAttribute="topMargin" id="d2P-9E-f7G"/>
+                                                <constraint firstItem="MFc-9U-CAg" firstAttribute="trailing" secondItem="6OQ-LK-des" secondAttribute="trailingMargin" id="lBc-pW-Irr"/>
+                                                <constraint firstItem="bY9-1y-Dau" firstAttribute="bottom" secondItem="6OQ-LK-des" secondAttribute="bottomMargin" id="uFy-AA-VgU"/>
+                                                <constraint firstItem="MFc-9U-CAg" firstAttribute="top" secondItem="6OQ-LK-des" secondAttribute="topMargin" constant="-4.5" id="yAB-As-B3a"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection footerTitle="Tell us if a machine does not exist anymore or is located elsewhere" id="nTw-xt-hpl">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ymV-67-V8M">
-                                        <rect key="frame" x="0.0" y="250.5" width="375" height="45.5"/>
+                                        <rect key="frame" x="0.0" y="484.5" width="375" height="45.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ymV-67-V8M" id="BEC-Lw-vl6">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45.5"/>
@@ -524,10 +639,12 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Settings" id="zx6-GS-7GO"/>
                     <connections>
+                        <outlet property="clusterPinsSwitch" destination="MFc-9U-CAg" id="59N-Ri-Hyc"/>
                         <outlet property="navigationbar" destination="zx6-GS-7GO" id="qrc-Ln-jyY"/>
                         <outlet property="pushSwitch" destination="IOA-uP-fPv" id="YhF-qT-r1e"/>
                         <outlet property="radiusSlider" destination="i4T-NX-O0k" id="RD6-uO-z5h"/>
                         <outlet property="reportProblemButton" destination="5ay-Q4-ROi" id="Pwg-G0-enY"/>
+                        <outlet property="retiredSwitch" destination="CAj-Vo-gk3" id="TDR-MO-yNc"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tGJ-xH-scI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/PennyMe/Base.lproj/Main.storyboard
+++ b/PennyMe/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="8oV-HC-UL6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="8oV-HC-UL6">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" showsUserLocation="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gN9-vW-D6p">
-                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                             </mapView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uvf-JL-VdF">
                                 <rect key="frame" x="318" y="590" width="47" height="47"/>
@@ -38,7 +38,7 @@
                                 <state key="normal" title="ToggleMap"/>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kVO-l0-XyT">
-                                <rect key="frame" x="10" y="54" width="50" height="50"/>
+                                <rect key="frame" x="10" y="74" width="50" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="3f5-Vi-bdK"/>
                                 </constraints>
@@ -97,14 +97,14 @@
                             <tableViewSection id="YX1-ej-Yw9">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="tJV-zg-KYa">
-                                        <rect key="frame" x="0.0" y="18" width="375" height="43"/>
+                                        <rect key="frame" x="0.0" y="18" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tJV-zg-KYa" id="cNb-TX-7RI">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b7j-4w-sXF">
-                                                    <rect key="frame" x="26" y="11" width="323" height="21"/>
+                                                    <rect key="frame" x="26" y="11" width="323" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -120,7 +120,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="fjs-hV-TPw">
-                                        <rect key="frame" x="0.0" y="61" width="375" height="210"/>
+                                        <rect key="frame" x="0.0" y="61.5" width="375" height="210"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fjs-hV-TPw" id="LOL-Ul-Er3">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="210"/>
@@ -146,7 +146,7 @@
                             <tableViewSection headerTitle="Status" footerTitle="Mark the penny machines you have alread visited or do not want to visit (&quot;marked&quot;), or machines that are out of order" id="1p5-KZ-43a">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="0Rf-TU-wLD">
-                                        <rect key="frame" x="0.0" y="334.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="335" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0Rf-TU-wLD" id="Uvs-MM-hr1">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -202,7 +202,7 @@
                             <tableViewSection id="Uy0-rC-cvY">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="nN5-QI-kia">
-                                        <rect key="frame" x="0.0" y="458" width="375" height="41"/>
+                                        <rect key="frame" x="0.0" y="458.5" width="375" height="41"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nN5-QI-kia" id="kbM-Er-FOS">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="41"/>
@@ -229,14 +229,14 @@
                             <tableViewSection headerTitle="Comments" id="AG4-72-6Vw">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Xfc-Oc-NxP">
-                                        <rect key="frame" x="0.0" y="555" width="375" height="43"/>
+                                        <rect key="frame" x="0.0" y="555.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xfc-Oc-NxP" id="OPC-2f-ym3">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No comments yet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c1X-rg-nvf">
-                                                    <rect key="frame" x="16" y="11" width="343" height="21"/>
+                                                    <rect key="frame" x="16" y="11" width="343" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -251,7 +251,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="N8K-xa-czH">
-                                        <rect key="frame" x="0.0" y="598" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="599" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="N8K-xa-czH" id="EbS-er-6Gh">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -277,7 +277,7 @@
                             <tableViewSection headerTitle="Further information" id="yoa-01-ZMn">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="wcD-oI-gR2">
-                                        <rect key="frame" x="0.0" y="697.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="698.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wcD-oI-gR2" id="mFT-jz-Gf6">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -302,7 +302,7 @@
                             <tableViewSection headerTitle="Contribute" footerTitle="Tell us if this machine has retired or if the address is not correct." id="wLy-lG-XH8">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="meO-D7-5e4">
-                                        <rect key="frame" x="0.0" y="805" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="806" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="meO-D7-5e4" id="GXP-u1-AO6">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -609,7 +609,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7cL-Kf-aJt">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="7cL-Kf-aJt">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31.5"/>
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cluster pins" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Kx-sy-Z7f">
@@ -694,13 +694,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8c0-bc-GIy">
-                                <rect key="frame" x="20" y="144" width="335" height="481"/>
+                                <rect key="frame" x="20" y="164" width="335" height="461"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PennyMe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" highlighted="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tGH-m2-P8R">
-                                <rect key="frame" x="126" y="78" width="123" height="36"/>
+                                <rect key="frame" x="126" y="98" width="123" height="36"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="T1T-E0-V0R"/>
                                 </constraints>
@@ -736,7 +736,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="8oV-HC-UL6" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Pzt-62-3P7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/PennyMe/PinViewController.swift
+++ b/PennyMe/PinViewController.swift
@@ -30,11 +30,11 @@ class PinViewController: UITableViewController, UIImagePickerControllerDelegate,
     let statusColors: [UIColor] = [.red, .green, .yellow, .gray]
     
     enum StatusChoice : String {
-            case unvisited
-            case visited
-            case marked
-            case retired
-        }
+        case unvisited
+        case visited
+        case marked
+        case retired
+    }
     
     @IBOutlet weak var textLabel: UILabel!
     @IBOutlet weak var imageView: UIImageView!

--- a/PennyMe/SettingsViewController.swift
+++ b/PennyMe/SettingsViewController.swift
@@ -18,10 +18,13 @@ class SettingsViewController: UITableViewController {
     @IBOutlet weak var pushSwitch: UISwitch!
     @IBOutlet weak var reportProblemButton: UIButton!
     @IBOutlet weak var radiusSlider: UISlider!
+    @IBOutlet weak var retiredSwitch: UISwitch!
+    @IBOutlet weak var clusterPinsSwitch: UISwitch!
+    // TODO: add other switches via drag and drop
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         if #available(iOS 13.0, *) {
             overrideUserInterfaceStyle = .light
             self.navigationbar.standardAppearance = UINavigationBarAppearance()
@@ -40,6 +43,15 @@ class SettingsViewController: UITableViewController {
         radius = Double(radiusSlider.value)
         radiusSlider.addTarget(self, action: #selector(sliderValueDidChange(_:)), for: .valueChanged)
         radiusSlider.isContinuous = false
+        
+        // cluster switch
+        clusterPinsSwitch.isOn = UserDefaults.standard.bool(forKey: "clusterPinSwitch")
+        clusterPinsSwitch.addTarget(self, action: #selector(clusterPins), for: .valueChanged)
+        
+        // retired switch
+        retiredSwitch.isOn = UserDefaults.standard.bool(forKey: "retiredSwitch")
+        retiredSwitch.addTarget(self, action: #selector(showRetiredMachines), for: .valueChanged)
+        // TODO: add other switches
     }
     
     @objc func reportProblem (sender: UIButton!){
@@ -47,6 +59,15 @@ class SettingsViewController: UITableViewController {
             "mailto:wnina@ethz.ch?subject=[PennyMe] - Problem report&body=Dear PennyMe team,\n\n I would like to inform you about the following problem in your app:\n\n"
         ).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "error"
         UIApplication.shared.openURL(URL(string:mailtostring )!)
+    }
+    
+    @objc func showRetiredMachines(sender:UISwitch!) {
+        UserDefaults.standard.set(sender.isOn, forKey: "retiredSwitch")
+        UserDefaults.standard.synchronize()
+    }
+    @objc func clusterPins(sender:UISwitch!) {
+        UserDefaults.standard.set(sender.isOn, forKey: "clusterPinSwitch")
+        UserDefaults.standard.synchronize()
     }
     
     @objc func sliderValueDidChange(_ sender:UISlider!)

--- a/PennyMe/SettingsViewController.swift
+++ b/PennyMe/SettingsViewController.swift
@@ -25,6 +25,14 @@ class SettingsViewController: UITableViewController {
     @IBOutlet weak var unvisitedSwitch: UISwitch!
     
     static var hasChanged = false
+    static var clusterHasChanged = false
+    let default_switches: [String: Bool] = [
+        "unvisitedSwitch": true,
+        "visitedSwitch": true,
+        "markedSwitch": true,
+        "retiredSwitch": false,
+        "clusterPinSwitch": false
+    ]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,20 +57,21 @@ class SettingsViewController: UITableViewController {
         radiusSlider.isContinuous = false
         
         // cluster switch
-        clusterPinsSwitch.isOn = UserDefaults.standard.bool(forKey: "clusterPinSwitch")
+        let user_settings = UserDefaults.standard
+        clusterPinsSwitch.isOn = user_settings.value(forKey: "clusterPinSwitch") as? Bool ?? default_switches["clusterPinSwitch"] as! Bool
         clusterPinsSwitch.addTarget(self, action: #selector(clusterPins), for: .valueChanged)
         // Machine status switches
         // 1) unvisited switch
-        unvisitedSwitch.isOn = UserDefaults.standard.bool(forKey: "unvisitedSwitch")
+        unvisitedSwitch.isOn = user_settings.value(forKey: "unvisitedSwitch") as? Bool ?? default_switches["unvisitedSwitch"] as! Bool
         unvisitedSwitch.addTarget(self, action: #selector(showUnvisitedMachines), for: .valueChanged)
         // 2) visied switch
-        visitedSwitch.isOn = UserDefaults.standard.bool(forKey: "visitedSwitch")
+        visitedSwitch.isOn = user_settings.value(forKey: "visitedSwitch") as? Bool ?? default_switches["visitedSwitch"] as! Bool
         visitedSwitch.addTarget(self, action: #selector(showVisitedMachines), for: .valueChanged)
         // 3) marked switch
-        markedSwitch.isOn = UserDefaults.standard.bool(forKey: "markedSwitch")
+        markedSwitch.isOn = user_settings.value(forKey: "markedSwitch") as? Bool ?? default_switches["markedSwitch"] as! Bool
         markedSwitch.addTarget(self, action: #selector(showMarkedMachines), for: .valueChanged)
         // 4) retired switch
-        retiredSwitch.isOn = UserDefaults.standard.bool(forKey: "retiredSwitch")
+        retiredSwitch.isOn = user_settings.value(forKey: "retiredSwitch") as? Bool ?? default_switches["retiredSwitch"] as! Bool
         retiredSwitch.addTarget(self, action: #selector(showRetiredMachines), for: .valueChanged)
         
     }
@@ -92,7 +101,12 @@ class SettingsViewController: UITableViewController {
     func userdefauls_helper(defaultsKey: String, isOn: Bool) {
         UserDefaults.standard.set(isOn, forKey: defaultsKey)
         UserDefaults.standard.synchronize()
-        SettingsViewController.hasChanged = true
+        if defaultsKey == "clusterPinSwitch" {
+            SettingsViewController.clusterHasChanged = true
+        }
+        else {
+            SettingsViewController.hasChanged = true
+        }
     }
     
     // Function for radius slider for push notifications

--- a/PennyMe/SettingsViewController.swift
+++ b/PennyMe/SettingsViewController.swift
@@ -20,7 +20,11 @@ class SettingsViewController: UITableViewController {
     @IBOutlet weak var radiusSlider: UISlider!
     @IBOutlet weak var retiredSwitch: UISwitch!
     @IBOutlet weak var clusterPinsSwitch: UISwitch!
-    // TODO: add other switches via drag and drop
+    @IBOutlet weak var markedSwitch: UISwitch!
+    @IBOutlet weak var visitedSwitch: UISwitch!
+    @IBOutlet weak var unvisitedSwitch: UISwitch!
+    
+    static var hasChanged = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -47,11 +51,20 @@ class SettingsViewController: UITableViewController {
         // cluster switch
         clusterPinsSwitch.isOn = UserDefaults.standard.bool(forKey: "clusterPinSwitch")
         clusterPinsSwitch.addTarget(self, action: #selector(clusterPins), for: .valueChanged)
-        
-        // retired switch
+        // Machine status switches
+        // 1) unvisited switch
+        unvisitedSwitch.isOn = UserDefaults.standard.bool(forKey: "unvisitedSwitch")
+        unvisitedSwitch.addTarget(self, action: #selector(showUnvisitedMachines), for: .valueChanged)
+        // 2) visied switch
+        visitedSwitch.isOn = UserDefaults.standard.bool(forKey: "visitedSwitch")
+        visitedSwitch.addTarget(self, action: #selector(showVisitedMachines), for: .valueChanged)
+        // 3) marked switch
+        markedSwitch.isOn = UserDefaults.standard.bool(forKey: "markedSwitch")
+        markedSwitch.addTarget(self, action: #selector(showMarkedMachines), for: .valueChanged)
+        // 4) retired switch
         retiredSwitch.isOn = UserDefaults.standard.bool(forKey: "retiredSwitch")
         retiredSwitch.addTarget(self, action: #selector(showRetiredMachines), for: .valueChanged)
-        // TODO: add other switches
+        
     }
     
     @objc func reportProblem (sender: UIButton!){
@@ -60,16 +73,29 @@ class SettingsViewController: UITableViewController {
         ).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "error"
         UIApplication.shared.openURL(URL(string:mailtostring )!)
     }
-    
+    // Functions for Switches
+    @objc func showUnvisitedMachines(sender:UISwitch!) {
+        userdefauls_helper(defaultsKey: "unvisitedSwitch", isOn: sender.isOn)
+    }
+    @objc func showVisitedMachines(sender:UISwitch!) {
+        userdefauls_helper(defaultsKey: "visitedSwitch", isOn: sender.isOn)
+    }
+    @objc func showMarkedMachines(sender:UISwitch!) {
+        userdefauls_helper(defaultsKey: "markedSwitch", isOn: sender.isOn)
+    }
     @objc func showRetiredMachines(sender:UISwitch!) {
-        UserDefaults.standard.set(sender.isOn, forKey: "retiredSwitch")
-        UserDefaults.standard.synchronize()
+        userdefauls_helper(defaultsKey: "retiredSwitch", isOn: sender.isOn)
     }
     @objc func clusterPins(sender:UISwitch!) {
-        UserDefaults.standard.set(sender.isOn, forKey: "clusterPinSwitch")
+        userdefauls_helper(defaultsKey: "clusterPinSwitch", isOn: sender.isOn)
+    }
+    func userdefauls_helper(defaultsKey: String, isOn: Bool) {
+        UserDefaults.standard.set(isOn, forKey: defaultsKey)
         UserDefaults.standard.synchronize()
+        SettingsViewController.hasChanged = true
     }
     
+    // Function for radius slider for push notifications
     @objc func sliderValueDidChange(_ sender:UISlider!)
     {
         radius =  Double(sender.value)

--- a/PennyMe/SettingsViewController.swift
+++ b/PennyMe/SettingsViewController.swift
@@ -28,7 +28,7 @@ class SettingsViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         if #available(iOS 13.0, *) {
             overrideUserInterfaceStyle = .light
             self.navigationbar.standardAppearance = UINavigationBarAppearance()

--- a/PennyMe/VersionManager.swift
+++ b/PennyMe/VersionManager.swift
@@ -1,0 +1,37 @@
+import Foundation
+import UIKit
+
+class VersionManager {
+    
+    static let shared = VersionManager()
+    
+    private let userDefaults = UserDefaults.standard
+    
+    private let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    
+    private let lastVersionKey = "last_version"
+    
+    func shouldShowVersionInfo() -> Bool {
+        if let lastVersion = userDefaults.string(forKey: lastVersionKey) {
+            print(lastVersion)
+            if lastVersion != currentVersion {
+                userDefaults.set(currentVersion, forKey: lastVersionKey)
+                return true
+            }
+        } else {
+            userDefaults.set(currentVersion, forKey: lastVersionKey)
+            return true
+        }
+        return false
+    }
+    
+    func showVersionInfoAlertIfNeeded() {
+        if shouldShowVersionInfo() {
+            let alert = UIAlertController(title: "PennyMe v\(currentVersion ?? "")", message: "Customize your map! \n This version includes new options to display pins on the map. Up to now, pins where clustered together when zooming out. From now on, you will see *all* pins on the map by default. Please also note that retired machines are now hidden by default. Tap the Settings button and play with the new \"map options\".", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            UIApplication.shared.windows.first?.rootViewController?.present(alert, animated: true, completion: nil)
+        }
+    }
+    
+}
+

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -53,6 +53,10 @@ class ViewController: UIViewController, UITextFieldDelegate {
     var currMap = 1
     let satelliteButton = UIButton(frame: CGRect(x: 10, y: 510, width: 50, height: 50))
     @IBOutlet weak var mapType : UISegmentedControl!
+    
+    // settings what to show on map
+    var retiredOn: Bool = false
+    var clusterPins: Bool = false
 
 
     override func viewDidLoad() {
@@ -93,6 +97,9 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
         loadInitialData()
         PennyMap.addAnnotations(artworks)
+        
+        // store pin settings
+        retiredOn = UserDefaults.standard.bool(forKey: "retiredSwitch")
 
         let button = UIButton()
         button.frame = CGRect(x: 150, y: 150, width: 100, height: 50)
@@ -106,8 +113,29 @@ class ViewController: UIViewController, UITextFieldDelegate {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        // check whether some setting has changed, if yes, reload all data on the map
+        checkPinSettings()
         // each time the view appears, check colours of the pins
         check_json_dict()
+        
+    }
+    
+    func checkPinSettings() {
+        // Function to update the map view if the settings change what to show on the map
+        let newRetiredOn = UserDefaults.standard.bool(forKey: "retiredSwitch")
+        let newClusterPins = UserDefaults.standard.bool(forKey: "clusterPinSwitch")
+        if (newRetiredOn != retiredOn)
+    ||  (newClusterPins != clusterPins) {
+            // reload data entirely
+            PennyMap.removeAnnotations(artworks)
+            artworks = []
+            pinIdDict = [:]
+            loadInitialData()
+            PennyMap.addAnnotations(artworks)
+            // update variables
+            retiredOn = newRetiredOn
+            clusterPins = newClusterPins
+        }
     }
     
     func setDelegates(){

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -38,6 +38,14 @@ class ViewController: UIViewController, UITextFieldDelegate {
     var pinIdDict : [String:Int] = [:]
     var selectedPin: Artwork?
     
+    let default_switches: [String: Bool] = [
+        "unvisitedSwitch": true,
+        "visitedSwitch": true,
+        "markedSwitch": true,
+        "retiredSwitch": false,
+        "clusterPinSwitch": false
+    ]
+    
     // Searchbar variables
     let searchController = UISearchController(searchResultsController: nil)
     var filteredArtworks: [Artwork] = []
@@ -113,22 +121,34 @@ class ViewController: UIViewController, UITextFieldDelegate {
             addAnnotationsIteratively()
             SettingsViewController.hasChanged = false
         }
+        if SettingsViewController.clusterHasChanged {
+            PennyMap.removeAnnotations(artworks)
+            addAnnotationsIteratively()
+            SettingsViewController.clusterHasChanged = false
+
+        }
         
     }
     
     func addAnnotationsIteratively() {
-        let relevantUserDefauls : [String] = ["unvisitedSwitch", "visitedSwitch", "markedSwitch", "retiredSwitch"]
+        let relevantUserDefauls : [String] = ["unvisitedSwitch", "visitedSwitch", "markedSwitch", "retiredSwitch", ]
         var includedStates : [String] = []
         for userdefault in relevantUserDefauls {
-            if UserDefaults.standard.bool(forKey: userdefault) {
+            let user_settings = UserDefaults.standard
+            let value = (user_settings.value(forKey: userdefault) as? Bool ?? default_switches[userdefault])
+            if value! {
                 let partStr = String( userdefault.prefix(userdefault.count - 6))
                 includedStates.append(partStr)
             }
         }
-        PennyMap.removeAnnotations(artworks)
+
         for artwork in artworks {
-            if includedStates.contains(artwork.status) {
-                PennyMap.addAnnotation(artwork)
+            if (includedStates.contains(artwork.status)) && (PennyMap.view(for: artwork) == nil) {
+            //  Artwork should be visible but is currently not visible
+                    PennyMap.addAnnotation(artwork)
+            } else if (!includedStates.contains(artwork.status)) && (PennyMap.view(for: artwork) != nil)  {
+                //  Artwork should not be visible but is currently not visible
+                PennyMap.removeAnnotation(artwork)
             }
         }
         

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -16,14 +16,6 @@ let LAT_DEGREE_TO_KM = 110.948
 let closeNotifyDist = 0.3 // in km, send "you are very close" at this distance
 var radius = 20.0
 
-class PreventClusteringMKMarkerAnnotationView: MKMarkerAnnotationView {
-    override var annotation: MKAnnotation? {
-        willSet {
-            displayPriority = MKFeatureDisplayPriority.required
-        }
-    }
-}
-
 @available(iOS 13.0, *)
 class ViewController: UIViewController, UITextFieldDelegate {
 
@@ -112,10 +104,6 @@ class ViewController: UIViewController, UITextFieldDelegate {
     
     }
     
-    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
-            return PreventClusteringMKMarkerAnnotationView(annotation: annotation, reuseIdentifier: "MyMarker")
-        }
-
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // each time the view appears, check colours of the pins
@@ -422,6 +410,7 @@ extension ViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         let gesture = UITapGestureRecognizer(target: self, action: #selector(ViewController.calloutTapped))
         view.addGestureRecognizer(gesture)
+        
     }
 
     @objc func calloutTapped(sender:UITapGestureRecognizer) {
@@ -433,9 +422,9 @@ extension ViewController: MKMapViewDelegate {
         self.performSegue(withIdentifier: "ShowPinViewController", sender: self)
     }
     
-//     callout when maps button is pressed
     func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView,
                  calloutAccessoryControlTapped control: UIControl) {
+        //     callout when maps button is pressed
         let location = view.annotation as! Artwork
         if (control == view.rightCalloutAccessoryView) {
             // This would open the directions

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -110,6 +110,8 @@ class ViewController: UIViewController, UITextFieldDelegate {
         addSettingsButton()
         toggleMapTypeButton()
     
+        // Check whether version is new
+        VersionManager.shared.showVersionInfoAlertIfNeeded()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -16,6 +16,14 @@ let LAT_DEGREE_TO_KM = 110.948
 let closeNotifyDist = 0.3 // in km, send "you are very close" at this distance
 var radius = 20.0
 
+class PreventClusteringMKMarkerAnnotationView: MKMarkerAnnotationView {
+    override var annotation: MKAnnotation? {
+        willSet {
+            displayPriority = MKFeatureDisplayPriority.required
+        }
+    }
+}
+
 @available(iOS 13.0, *)
 class ViewController: UIViewController, UITextFieldDelegate {
 
@@ -104,6 +112,10 @@ class ViewController: UIViewController, UITextFieldDelegate {
     
     }
     
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            return PreventClusteringMKMarkerAnnotationView(annotation: annotation, reuseIdentifier: "MyMarker")
+        }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // each time the view appears, check colours of the pins

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -53,10 +53,6 @@ class ViewController: UIViewController, UITextFieldDelegate {
     var currMap = 1
     let satelliteButton = UIButton(frame: CGRect(x: 10, y: 510, width: 50, height: 50))
     @IBOutlet weak var mapType : UISegmentedControl!
-    
-    // settings what to show on map
-    var retiredOn: Bool = false
-    var clusterPins: Bool = false
 
 
     override func viewDidLoad() {
@@ -97,9 +93,6 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
         loadInitialData()
         addAnnotationsIteratively()
-        
-        // store pin settings
-        retiredOn = UserDefaults.standard.bool(forKey: "retiredSwitch")
 
         let button = UIButton()
         button.frame = CGRect(x: 150, y: 150, width: 100, height: 50)
@@ -124,7 +117,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     }
     
     func addAnnotationsIteratively() {
-        let relevantUserDefauls : [String] = ["unvisitedSwitch","visitedSwitch", "markedSwitch", "retiredSwitch"]
+        let relevantUserDefauls : [String] = ["unvisitedSwitch", "visitedSwitch", "markedSwitch", "retiredSwitch"]
         var includedStates : [String] = []
         for userdefault in relevantUserDefauls {
             if UserDefaults.standard.bool(forKey: userdefault) {
@@ -445,7 +438,6 @@ extension ViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         let gesture = UITapGestureRecognizer(target: self, action: #selector(ViewController.calloutTapped))
         view.addGestureRecognizer(gesture)
-        
     }
 
     @objc func calloutTapped(sender:UITapGestureRecognizer) {


### PR DESCRIPTION
This PR includes several new options about which pins are displayed on the map

Under Settings -> map options:
- a toggle whether pins are aggregated when zooming out of the map. This defaults to False. In the past, the default used to be True and the user did not have the option to change this
- a toggle to filter machines by state ("visited", "unvisited", "marked", "retired"). One toggle for each state. The retired state defaults to False, which differs from the past behavior

Also there will now a pop up be displayed if the user installs a new version of the app. The pop up displays some custom content describing the update