### PR TITLE
fix network connection problems with xcode simulator

### DIFF
--- a/PennyMe/Info.plist
+++ b/PennyMe/Info.plist
@@ -63,5 +63,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
I had problems loading the server_locations file when working in the simulator (doesn't happen on real devices). This line in the plist.info fixed it.