### PR TITLE
Updates from website (server_locations)

### DIFF
--- a/data/server_locations.json
+++ b/data/server_locations.json
@@ -42178,6 +42178,29 @@
                 "id": 1033,
                 "last_updated": "2024-01-06"
             }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -82.13853139999999,
+                    38.8427256
+                ]
+            },
+            "properties": {
+                "name": "Mothman Museum",
+                "area": "West Virginia",
+                "address": "400 Main St,, Point Pleasent",
+                "status": "unvisited",
+                "external_url": "http://209.221.138.252/Details.aspx?location=420295",
+                "internal_url": "null",
+                "latitude": "38.8427256",
+                "longitude": "-82.13853139999999",
+                "machine_status": "available",
+                "id": 7030,
+                "last_updated": "2024-01-06"
+            }
         }
     ]
 }

--- a/data/server_locations.json
+++ b/data/server_locations.json
@@ -1677,9 +1677,9 @@
                 "latitude": "44.9410879",
                 "longitude": "-123.0430662",
                 "multimachine": 2,
-                "machine_status": "retired",
+                "machine_status": "available",
                 "id": 4390,
-                "last_updated": "2023-07-15"
+                "last_updated": "2024-01-06"
             }
         },
         {
@@ -8051,9 +8051,9 @@
                 "internal_url": "null",
                 "latitude": "37.33230210000001",
                 "longitude": "-121.8897436",
-                "machine_status": "available",
+                "machine_status": "retired",
                 "id": 6125,
-                "last_updated": "2023-10-14"
+                "last_updated": "2024-01-06"
             }
         },
         {
@@ -42108,6 +42108,75 @@
                 "machine_status": "available",
                 "id": 7027,
                 "last_updated": "2024-01-05"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    8.9674035,
+                    48.3235588
+                ]
+            },
+            "properties": {
+                "name": "Hohenzollern Castle",
+                "area": "Germany",
+                "address": " Burg Hohenzollern, Hechingen",
+                "status": "unvisited",
+                "external_url": "http://209.221.138.252/Details.aspx?location=420188",
+                "internal_url": "null",
+                "latitude": "48.3235588",
+                "longitude": "8.9674035",
+                "machine_status": "available",
+                "id": 7028,
+                "last_updated": "2024-01-06"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -4.0211187,
+                    39.8573595
+                ]
+            },
+            "properties": {
+                "name": "Regalos Torres",
+                "area": "Spain",
+                "address": "Cta. de los Capuchinos, 12, 45001 Toledo, Toledo",
+                "status": "unvisited",
+                "external_url": "http://209.221.138.252/Details.aspx?location=420135",
+                "internal_url": "null",
+                "latitude": "39.8573595",
+                "longitude": "-4.0211187",
+                "machine_status": "available",
+                "id": 7029,
+                "last_updated": "2024-01-06"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    25.2505253,
+                    35.3111827
+                ]
+            },
+            "properties": {
+                "name": "WaterCity Waterpark",
+                "area": "Greece",
+                "address": "Anopolis, Crete",
+                "external_url": "null",
+                "internal_url": "null",
+                "latitude": "35.3111827",
+                "longitude": "25.2505253",
+                "machine_status": "retired",
+                "status": "retired",
+                "id": 1033,
+                "last_updated": "2024-01-06"
             }
         }
     ]


### PR DESCRIPTION
2024-01-07 22:30:02 INFO ======Location differ joblog from 2024-01-07 22:30:02=======
2024-01-07 22:39:53 INFO Salem's Riverfront Carousel is available again
2024-01-07 22:40:11 INFO Location Oregon (8/125): Changes in 1/127 machines found.
2024-01-07 22:48:59 INFO Christmas in the Park is currently unavailable
2024-01-07 22:50:23 INFO Location California (12/125): Changes in 1/751 machines found.
2024-01-07 23:16:58 ERROR Geolocation failed for: Unknown Location 	 sub: , Arco
2024-01-07 23:46:56 INFO 165/367: Found machine to be added: Hohenzollern Castle
2024-01-07 23:49:52 INFO Location Germany (73/125): Changes in 1/367 machines found.
2024-01-08 00:06:29 INFO 154/167: Found machine to be added: Regalos Torres
2024-01-08 00:06:41 INFO Location Spain (112/125): Changes in 1/167 machines found.
2024-01-08 00:09:03 INFO 
 Result: 4 changes, 3 new machines found and 1 machines retired
2024-01-08 00:13:34 ERROR Our machine WaterCity Waterpark in Greece from Device shown as retired but http://209.221.138.252/Details.aspx?location=241893 responds Internal Server Error (500)
2024-01-08 00:31:30 ERROR Found 5 problems that require manual intervention
2024-01-08 00:31:30 INFO ======Location differ completed at 2024-01-08 00:31:30=======
2024-01-08 00:31:30 INFO Detected change in server_locations.json - push to github
