### PR TITLE
Change 712 "Wasserkirche (Zürich)" - Changed:
	Title from: Wasserkirche (ZÃ¼rich) to: Wasserkirche (Zürich)
	Address from Teddy's Souvenir shop, Limmatquai 34, 8001 Zurich, Switzerland to: Teddy's%20Souvenir%20shop,%20+Limmatquai&%20%2034,%208001%20Zurich,%20Switzerland

### DIFF
--- a/data/server_locations.json
+++ b/data/server_locations.json
@@ -43408,6 +43408,29 @@
                 "id": 3445,
                 "last_updated": "2024-02-04"
             }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    8.543325,
+                    47.370296
+                ]
+            },
+            "properties": {
+                "name": "Wasserkirche (Zürich)",
+                "area": "Switzerland",
+                "address": "Teddy's%20Souvenir%20shop,%20+Limmatquai&%20%2034,%208001%20Zurich,%20Switzerland",
+                "external_url": "http://209.221.138.252/Details.aspx?location=103894",
+                "internal_url": "null",
+                "latitude": "47.370296",
+                "longitude": "8.543325",
+                "machine_status": "available",
+                "status": "unvisited",
+                "id": 712,
+                "last_updated": "2024-02-06"
+            }
         }
     ]
 }

--- a/data/server_locations.json
+++ b/data/server_locations.json
@@ -43431,6 +43431,29 @@
                 "id": 712,
                 "last_updated": "2024-02-06"
             }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    8.491475,
+                    47.349676
+                ]
+            },
+            "properties": {
+                "name": "Ütliberg Kulm",
+                "area": "Switzerland",
+                "address": "8143 Zurich/&Z%C3%BCrich, Switzerland",
+                "external_url": "http://209.221.138.252/Details.aspx?location=76235",
+                "internal_url": "null",
+                "latitude": "47.349676",
+                "longitude": "8.491475",
+                "machine_status": "available",
+                "status": "unvisited",
+                "id": 711,
+                "last_updated": "2024-02-06"
+            }
         }
     ]
 }


### PR DESCRIPTION
Change 712 "Wasserkirche (Zürich)" - Changed:
	Title from: Wasserkirche (ZÃ¼rich) to: Wasserkirche (Zürich)
	Address from Teddy's Souvenir shop, Limmatquai 34, 8001 Zurich, Switzerland to: Teddy's%20Souvenir%20shop,%20+Limmatquai&%20%2034,%208001%20Zurich,%20Switzerland