### PR TITLE
Machine updates

### DIFF
--- a/data/server_locations.json
+++ b/data/server_locations.json
@@ -46027,6 +46027,29 @@
                 "last_updated": "2024-03-10",
                 "multimachine": 2
             }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -93.739556,
+                    32.519008
+                ]
+            },
+            "properties": {
+                "name": "Louisiana Boardwalk - Fuddruckers",
+                "area": "Louisiana",
+                "address": "390 Plaza Loop Dr, Bossier City",
+                "external_url": "http://209.221.138.252/Details.aspx?location=16098",
+                "internal_url": "null",
+                "latitude": "32.519008",
+                "longitude": "-93.739556",
+                "machine_status": "retired",
+                "status": "unvisited",
+                "id": 3566,
+                "last_updated": "2024-03-10"
+            }
         }
     ]
 }


### PR DESCRIPTION
2024-03-10 22:30:01 INFO ======Location differ joblog from 2024-03-10 22:30:01=======
2024-03-10 22:31:04 INFO Louisiana Boardwalk - Fuddruckers is currently unavailable
2024-03-10 22:31:42 INFO Location Louisiana (1/125): Changes in 1/88 machines found.
2024-03-10 23:16:18 ERROR Geolocation failed for: Unknown Location 	 sub: , Arco
2024-03-11 00:08:03 INFO 
 Result: 1 changes, 0 new machines found and 1 machines retired
2024-03-11 00:22:18 ERROR Found 5 problems that require manual intervention
2024-03-11 00:22:18 INFO ======Location differ completed at 2024-03-11 00:22:18=======
2024-03-11 00:22:18 INFO Detected change in server_locations.json - push to github
