### PR TITLE
Improved machine location change map view + backend relaxation for new machines

### DIFF
--- a/PennyMe/NewMachineRequest.swift
+++ b/PennyMe/NewMachineRequest.swift
@@ -175,11 +175,11 @@ struct NewMachineFormView: View {
                 }.padding().disabled(isLoading)
             }
             
-            AlertPresenter(showAlert: $showFinishedAlert, title: "Finished", message: "Thanks for suggesting this machine. We will review this request shortly. Note that it can take up to a few days until the machine becomes visible.")
+            AlertPresenter(showAlert: $showFinishedAlert, title: "Finished", message: "Thanks for suggesting this machine. We will review this request shortly. Note that it may take a few days until the machine becomes visible.")
                 .padding()
         }
         .alert(isPresented: $showAlert) {
-                    Alert(title: Text("Attention!"), message: Text(displayResponse), dismissButton: .default(Text("Dismiss")))
+                    Alert(title: Text("Error!"), message: Text(displayResponse), dismissButton: .default(Text("Dismiss")))
                 }
         .padding()
         .navigationBarTitle("Add new machine")


### PR DESCRIPTION
- Machine location change map view now shows also the map view toggle thus supporting hybrid and satellite map (user request)
- New machines with incorrect address (>1km away) are no longer rejected since this may make it impossible to submit a new machine. Instead, it's a success but a warning is given to slack (AKA developer team) to verify the new machine


<img width="343" alt="image" src="https://github.com/jannisborn/PennyMe/assets/15703818/7f4bc74c-d872-4cd5-9054-4e7fb40a630e">
