### PR TITLE
Machine updates

### DIFF
--- a/data/server_locations.json
+++ b/data/server_locations.json
@@ -37571,6 +37571,27 @@
                 "id": 224,
                 "last_updated": "2025-12-21"
             }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -81.31316869999998,
+                    29.89450090000001
+                ]
+            },
+            "properties": {
+                "name": "St. George's Row Shops",
+                "area": "Florida",
+                "address": "106 St. George St., St. Augustine",
+                "external_url": "http://locations.pennycollector.com/Details.aspx?location=1553",
+                "internal_url": "null",
+                "machine_status": "available",
+                "status": "unvisited",
+                "id": 3457,
+                "last_updated": "2025-12-21"
+            }
         }
     ]
 }


### PR DESCRIPTION
Change 1469 "Navid Nuur Exhibition, Parasol Exhibition Unit":
	 Location from: 51.5303, -0.0949 to: 51.5303, -0.0949