### PR TITLE
fix: make zoomviewcontroller single image and set to the correct image

### DIFF
--- a/PennyMe/PinViewController.swift
+++ b/PennyMe/PinViewController.swift
@@ -63,7 +63,7 @@ class PinViewController: UITableViewController, UIImagePickerControllerDelegate,
     
     var imagePicker = UIImagePickerController()
     
-    var imageList: [UIImage] = []
+    var imageDict: [Int: UIImage] = [:]
     private var pendingImageIndex: Int?
     
     var artwork: Artwork? {
@@ -736,9 +736,10 @@ class PinViewController: UITableViewController, UIImagePickerControllerDelegate,
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if (segue.identifier == "bigImage") {
             let destinationViewController = segue.destination as! ZoomViewController
-            destinationViewController.images = imageList
-            let currentPosition = scrollView.contentOffset.x / scrollView.frame.width
-            destinationViewController.scrollPosition = currentPosition        }
+            if let idx = pendingImageIndex {
+                destinationViewController.image = imageDict[idx]
+            }
+        }
         
     }
     
@@ -767,7 +768,7 @@ class PinViewController: UITableViewController, UIImagePickerControllerDelegate,
                 if let downloadedImage {
                     finalImage = downloadedImage
                     action = #selector(self.enlargeImage(tapGestureRecognizer:))
-                    self.imageList.append(downloadedImage)
+                    self.imageDict[photoInd] = downloadedImage
                 } else {
                     // pick default
                     let isCoin = urlString.contains("coin")
@@ -895,6 +896,8 @@ class PinViewController: UITableViewController, UIImagePickerControllerDelegate,
     
     @objc func enlargeImage(tapGestureRecognizer: UITapGestureRecognizer)
     {
+        guard let tappedView = tapGestureRecognizer.view else { return }
+        pendingImageIndex = tappedView.tag
         self.performSegue(withIdentifier: "bigImage", sender: self)
     }
     

--- a/PennyMe/ZoomViewController.swift
+++ b/PennyMe/ZoomViewController.swift
@@ -13,8 +13,7 @@ class ZoomViewController: UIViewController, UIScrollViewDelegate {
     @IBOutlet weak var bigImageView: UIImageView!
     @IBOutlet weak var scrollView: UIScrollView!
     
-    var images: [UIImage] = []
-    var scrollPosition : CGFloat = 0
+    var image: UIImage!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,34 +21,20 @@ class ZoomViewController: UIViewController, UIScrollViewDelegate {
             overrideUserInterfaceStyle = .light
         }
         
+        self.bigImageView.image = image
+        self.view.addSubview(bigImageView)
         scrollView.delegate = self
-        scrollView.isPagingEnabled = true
         
-        // set the scroll view size based on the number of images
-        scrollView.contentSize = CGSize(width: view.frame.width * CGFloat(images.count), height: scrollView.frame.height)
-        
-        // set zoom scale
-        scrollView.minimumZoomScale = 1
-        scrollView.maximumZoomScale = 3.0
-        
-        // move the scollView to the required position
-        let scrollPoint = CGPoint(x: scrollPosition * scrollView.frame.width, y: 0)
-        scrollView.setContentOffset(scrollPoint, animated: false)
-        
-        // add all images to the scrollview
-        for (idx, image) in images.enumerated() {
-            let imageView = UIImageView(image: image)
-            let xPosition = view.frame.width * CGFloat(idx)
-            imageView.frame = CGRect(x: xPosition, y: 0, width: view.frame.width, height: scrollView.frame.height)
-            imageView.contentMode = .scaleAspectFit
-            imageView.isUserInteractionEnabled = true
-            scrollView.addSubview(imageView)
-        }
+        let minScale = min(scrollView.frame.size.width / bigImageView.frame.size.width, scrollView.frame.size.height / bigImageView.frame.size.height);
+        scrollView.minimumZoomScale = minScale
+        scrollView.maximumZoomScale = 4.0 * minScale
+        scrollView.contentSize = bigImageView.frame.size
+        scrollView.addSubview(bigImageView)
         
     }
     
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-        return scrollView.subviews.first
+            return bigImageView
     }
 
 }


### PR DESCRIPTION
The loaded images are now saved in a dictionary with the correct index. When clicking on the image, the index is passed to the segue-method and the correct image is displayed.
Tested on simulator and phone.