### PR TITLE
feat: Validate new machine requests

### DIFF
--- a/PennyMe/NewMachineRequest.swift
+++ b/PennyMe/NewMachineRequest.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import MapKit
+import UIKit
 
 // RequestFormView.swift
 
@@ -80,7 +81,42 @@ struct ConfirmationMessageView: View {
 
 @available(iOS 14.0, *)
 struct NewMachineFormView: View {
+    private struct NearbyMachine: Identifiable {
+        let machineID: String
+        let name: String
+        let status: String
+        let distance: Int
+        var id: String { machineID }
+
+        init?(json: [String: Any]) {
+            guard let name = json["name"] as? String,
+                  let status = json["machine_status"] as? String,
+                  let machineID = json["id"],
+                  let distance = json["distance_m"] as? NSNumber else {
+                return nil
+            }
+            self.machineID = "\(machineID)"
+            self.name = name
+            self.status = status
+            self.distance = distance.intValue
+        }
+
+        var statusColor: Color {
+            switch status {
+            case "available":
+                return .red
+            case "out-of-order", "retired":
+                return .gray
+            default:
+                return .black
+            }
+        }
+    }
+
     let coords: CLLocationCoordinate2D
+    let areaChoices: [String]
+    let openExistingMachine: ((String) -> Void)?
+    let isExistingMachineVisible: ((String) -> Bool)?
     // Properties to hold user input
     @State private var name: String = ""
     @State private var address: String = ""
@@ -95,13 +131,24 @@ struct NewMachineFormView: View {
     @State private var selectedImage: UIImage? = nil
     @State private var isImagePickerPresented: Bool = false
     @State private var showAlert = false
+    @State private var duplicateMachine: NearbyMachine? = nil
+    @State private var nearbyMachines: [NearbyMachine] = []
+    @State private var nearbyConfirmationPending = false
     @State private var isLoading = false
 
     @State private var keyboardHeight: CGFloat = 0
     private var keyboardObserver: AnyCancellable?
 
-    init(coordinate: CLLocationCoordinate2D) {
+    init(
+        coordinate: CLLocationCoordinate2D,
+        areaChoices: [String] = [],
+        openExistingMachine: ((String) -> Void)? = nil,
+        isExistingMachineVisible: ((String) -> Bool)? = nil
+    ) {
         coords = coordinate
+        self.areaChoices = areaChoices
+        self.openExistingMachine = openExistingMachine
+        self.isExistingMachineVisible = isExistingMachineVisible
         _selectedLocation = State(initialValue: coords)
         // Observe keyboard frame changes
         keyboardObserver = NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)
@@ -139,6 +186,20 @@ struct NewMachineFormView: View {
             // Area input field
             TextField("Area (Country or US state)", text: $area)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
+            if !matchingAreas.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(matchingAreas.prefix(5), id: \.self) { areaChoice in
+                        Button(action: {
+                            area = areaChoice
+                        }) {
+                            Text(areaChoice)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+                .font(.footnote)
+                .padding(.horizontal, 4)
+            }
 
             
             // Paywall checkbox
@@ -194,27 +255,157 @@ struct NewMachineFormView: View {
                 .padding()
         }
         .alert(isPresented: $showAlert) {
-                    Alert(title: Text("Error!"), message: Text(displayResponse), dismissButton: .default(Text("Dismiss")))
-                }
+            return Alert(title: Text("Error!"), message: Text(displayResponse), dismissButton: .default(Text("Dismiss")))
+        }
         .padding()
         .navigationBarTitle("Add new machine")
         .sheet(isPresented: $isImagePickerPresented) {
             ImagePicker(selectedImage: $selectedImage, sourceType: .photoLibrary)
         }
+        .overlay(warningOverlay)
         }
         .padding(.bottom, keyboardHeight)
     }
+
+    @ViewBuilder
+    private var warningOverlay: some View {
+        ZStack {
+            if let duplicateMachine = duplicateMachine {
+                warningBackdrop
+                warningBox {
+                    Text("This machine already exists")
+                        .font(.headline)
+                    machineLine(duplicateMachine)
+                    if ["out-of-order", "retired"].contains(duplicateMachine.status) {
+                        Text("Cool! You re-discovered a machine that was marked as \(duplicateMachine.status).")
+                        Text("Please change its status to 'Active'.")
+                    }
+                    if isExistingMachineVisible?(duplicateMachine.machineID) == false {
+                        Text("You didn't see this machine on the map because in your settings you toggled \(duplicateMachine.status) machines to be invisible.")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
+                    Button(action: {
+                        self.duplicateMachine = nil
+                        openExistingMachine?(duplicateMachine.machineID)
+                    }) {
+                        primaryButtonLabel("Open existing machine")
+                    }
+                    Button(action: {
+                        self.duplicateMachine = nil
+                    }) {
+                        secondaryButtonLabel("Cancel")
+                    }
+                }
+            } else if nearbyConfirmationPending {
+                warningBackdrop
+                warningBox {
+                    Text("\(nearbyMachines.count) Nearby machines found!")
+                        .font(.headline)
+                    Text("This may already be in PennyMe. Do you still want to submit this machine?")
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(nearbyMachines) { machine in
+                            machineLine(machine)
+                        }
+                    }
+                    Button(action: {
+                        nearbyConfirmationPending = false
+                        submitRequest(ignoreNearby: true)
+                    }) {
+                        secondaryButtonLabel("Submit anyway")
+                    }
+                    Button(action: {
+                        nearbyConfirmationPending = false
+                    }) {
+                        primaryButtonLabel("Cancel")
+                    }
+                }
+            }
+        }
+    }
+
+    private var warningBackdrop: some View {
+        Color.black.opacity(0.3).edgesIgnoringSafeArea(.all)
+    }
+
+    private var matchingAreas: [String] {
+        let query = area.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return [] }
+        return areaChoices.filter {
+            $0.localizedCaseInsensitiveContains(query) && $0.caseInsensitiveCompare(query) != .orderedSame
+        }
+    }
+
+    private var submittedArea: String {
+        let query = area.trimmingCharacters(in: .whitespacesAndNewlines)
+        return areaChoices.first { $0.caseInsensitiveCompare(query) == .orderedSame } ?? query
+    }
+
+    private func warningBox<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 14, content: content)
+            .padding()
+            .frame(maxWidth: 360)
+            .background(Color(UIColor.systemBackground))
+            .cornerRadius(10)
+            .shadow(radius: 8)
+            .padding()
+    }
+
+    // One-line nearby machine summary with status colored like map pins.
+    private func machineLine(_ machine: NearbyMachine) -> Text {
+        Text("\(machine.distance)m: \(machine.name) (")
+            + Text(machine.status).foregroundColor(machine.statusColor)
+            + Text(")")
+    }
+
+    private func primaryButtonLabel(_ title: String) -> some View {
+        Text(title)
+            .padding()
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .background(Color.blue)
+            .cornerRadius(10)
+    }
+
+    private func secondaryButtonLabel(_ title: String) -> some View {
+        Text(title)
+            .padding()
+            .frame(maxWidth: .infinity)
+    }
     
     private func finishLoading(message: String) {
-        displayResponse = message
-        showAlert = true
-        isLoading = false
+        DispatchQueue.main.async {
+            displayResponse = message
+            duplicateMachine = nil
+            nearbyConfirmationPending = false
+            showAlert = true
+            isLoading = false
+        }
+    }
+
+    // Show a hard stop for a machine that already exists.
+    private func showDuplicateMachine(machine: NearbyMachine) {
+        DispatchQueue.main.async {
+            duplicateMachine = machine
+            nearbyConfirmationPending = false
+            isLoading = false
+        }
+    }
+
+    // Show the backend warning for nearby machines and let the user override it.
+    private func confirmNearbyMachines(machines: [NearbyMachine]) {
+        DispatchQueue.main.async {
+            duplicateMachine = nil
+            nearbyMachines = machines
+            nearbyConfirmationPending = true
+            isLoading = false
+        }
     }
     
     // Function to handle the submission of the request
-    private func submitRequest() {
+    private func submitRequest(ignoreNearby: Bool = false) {
         isLoading = true
-        if name == "" || address == "" || area == "" || selectedImage == nil {
+        if name == "" || address == "" || submittedArea == "" || selectedImage == nil {
             finishLoading(message: "Please enter all information & upload image")
         } else {
 
@@ -231,12 +422,13 @@ struct NewMachineFormView: View {
                 urlComponents.queryItems = [
                     URLQueryItem(name: "title", value: name),
                     URLQueryItem(name: "address", value: address),
-                    URLQueryItem(name: "area", value: area),
+                    URLQueryItem(name: "area", value: submittedArea),
                     URLQueryItem(name: "multimachine", value: multimachine),
                     URLQueryItem(name:"paywall", value: String(paywall)),
                     URLQueryItem(name:"num_coins", value: String(numCoins)),
                     URLQueryItem(name: "lon_coord", value: "\(selectedLocation.longitude)"),
                     URLQueryItem(name: "lat_coord", value: "\(selectedLocation.latitude)"),
+                    URLQueryItem(name: "ignore_nearby", value: String(ignoreNearby)),
                 ]
                 urlComponents.percentEncodedQuery = urlComponents.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
                 var request = URLRequest(url: urlComponents.url!)
@@ -283,6 +475,20 @@ struct NewMachineFormView: View {
                                 if let json = try JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any] {
                                     // Handle the JSON data here
                                     if let answerString = json["error"] as? String {
+                                        if statusCode == 409,
+                                           let duplicateJSON = json["duplicate_machine"] as? [String: Any],
+                                           let duplicateMachine = NearbyMachine(json: duplicateJSON) {
+                                            showDuplicateMachine(machine: duplicateMachine)
+                                            return
+                                        }
+                                        if statusCode == 409,
+                                           let nearbyJSON = json["nearby_machines"] as? [[String: Any]] {
+                                            let nearbyMachines = nearbyJSON.compactMap(NearbyMachine.init)
+                                            if !nearbyMachines.isEmpty {
+                                                confirmNearbyMachines(machines: nearbyMachines)
+                                                return
+                                            }
+                                        }
                                         finishLoading(message: answerString)
                                         return
                                     }

--- a/PennyMe/ViewController.swift
+++ b/PennyMe/ViewController.swift
@@ -202,11 +202,41 @@ class ViewController: UIViewController, UITextFieldDelegate, UIGestureRecognizer
         if #available(iOS 14.0, *) {
             // center on current location
             if let coordinate = PennyMe.locationManager.location?.coordinate{
-                let swiftUIViewController = UIHostingController(rootView: NewMachineFormView(coordinate: coordinate)
-                )
+                let swiftUIViewController = UIHostingController(rootView: newMachineForm(coordinate: coordinate))
                 present(swiftUIViewController, animated: true)
             }
         }
+    }
+
+    @available(iOS 14.0, *)
+    private func newMachineForm(coordinate: CLLocationCoordinate2D) -> NewMachineFormView {
+        NewMachineFormView(
+            coordinate: coordinate,
+            areaChoices: Array(Set(artworks.map { $0.area })).sorted(),
+            openExistingMachine: { [weak self] machineID in
+                self?.dismiss(animated: true) {
+                    self?.openMachine(machineID: machineID)
+                }
+            },
+            isExistingMachineVisible: { [weak self] machineID in
+                self?.isMachineVisible(machineID: machineID) ?? true
+            }
+        )
+    }
+
+    private func openMachine(machineID: String) {
+        guard let pinIndex = pinIdDict[machineID] else { return }
+        selectedPin = artworks[pinIndex]
+        let center = selectedPin!.coordinate
+        let region = MKCoordinateRegion(center: center, span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
+        PennyMap.setRegion(region, animated: true)
+        performSegue(withIdentifier: "ShowPinViewController", sender: self)
+    }
+
+    private func isMachineVisible(machineID: String) -> Bool {
+        guard let pinIndex = pinIdDict[machineID] else { return true }
+        let machine = artworks[pinIndex]
+        return checkMachineShouldBeVisible(status: machine.status, machineStatus: machine.machineStatus)
     }
     
     @objc private func didTapSettings() {
@@ -647,8 +677,7 @@ extension ViewController: MKMapViewDelegate {
         // first option: it's a new machine pin - present form
         if let newmachine = annotation as? NewMachine {
             if #available(iOS 14.0, *) {
-                let swiftUIViewController = UIHostingController(rootView: NewMachineFormView(coordinate: newmachine.coordinate)
-                )
+                let swiftUIViewController = UIHostingController(rootView: newMachineForm(coordinate: newmachine.coordinate))
                 present(swiftUIViewController, animated: true, completion: removeNewMachinePin)
                 
             }

--- a/backend/app.py
+++ b/backend/app.py
@@ -15,6 +15,11 @@ from flask import Flask, jsonify, request
 from googlemaps import Client as GoogleMaps
 from haversine import haversine
 from loguru import logger
+from thefuzz import process as fuzzysearch
+
+from scripts.location_differ import location_differ
+from scripts.open_diff_pull_request import open_differ_pr
+
 from pennyme.github_update import (
     get_latest_commit_time,
     load_latest_json,
@@ -29,10 +34,11 @@ from pennyme.slack import (
     message_slack_raw,
     process_uploaded_image,
 )
-from pennyme.utils import find_machine_in_database, setup_locdiffer_logger
-from scripts.location_differ import location_differ
-from scripts.open_diff_pull_request import open_differ_pr
-from thefuzz import process as fuzzysearch
+from pennyme.utils import (
+    find_machine_in_database,
+    get_nearby_machines,
+    setup_locdiffer_logger,
+)
 
 app = Flask(__name__)
 request_queue = queue.Queue()
@@ -253,7 +259,11 @@ def address_to_coordinates(
 
 @app.route("/create_machine", methods=["POST"])
 def create_machine():
-    """Receives a new machine"""
+    """Receive and queue a new machine submission.
+
+    Returns:
+        JSON response with success, validation error, or nearby-machine warning.
+    """
     title = str(request.args.get("title")).strip()
     address = str(request.args.get("address")).strip()
     area = str(request.args.get("area")).strip()
@@ -274,6 +284,37 @@ def create_machine():
         float(request.args.get("lon_coord")),
         float(request.args.get("lat_coord")),
     )
+    nearby_machines = get_nearby_machines(location[1], location[0], area)
+    for machine in nearby_machines:
+        _, score = fuzzysearch.extract(title, [machine["name"]], limit=1)[0]
+        if score > 90:
+            return (
+                jsonify(
+                    {
+                        "error": "This machine already exists",
+                        "duplicate_machine": {**machine, "title_match_score": score},
+                    }
+                ),
+                409,
+            )
+
+    if request.args.get("ignore_nearby") != "true" and nearby_machines:
+        nearby_lines = [
+            f"{machine['distance_m']}m: {machine['name']} ({machine['machine_status']})"
+            for machine in nearby_machines
+        ]
+        return (
+            jsonify(
+                {
+                    "error": f"{len(nearby_machines)} nearby machines found:\n"
+                    + "\n".join(nearby_lines)
+                    + "\n\nDo you still want to submit this machine?",
+                    "nearby_machines": nearby_machines,
+                }
+            ),
+            409,
+        )
+
     # Verify that address matches coordinates
     found_coords, (lat, lng) = address_to_coordinates(address, area, title)
     if not found_coords:

--- a/backend/pennyme/utils.py
+++ b/backend/pennyme/utils.py
@@ -3,9 +3,11 @@ import os
 import sys
 from contextlib import contextmanager
 from copy import deepcopy
+from math import cos, radians
 from typing import Any, Dict, List, Tuple
 
 import requests
+from haversine import haversine
 from loguru import logger
 
 from pennyme.pennycollector import DAY, MONTH, YEAR
@@ -17,8 +19,16 @@ THIS_PATH = os.path.abspath(__file__)
 PATH_MACHINES = os.path.join(
     os.path.dirname(THIS_PATH), "..", "..", "data", "all_locations.json"
 )
-with open(PATH_MACHINES, "r", encoding="latin-1") as infile:
+PATH_SERVER_MACHINES = os.path.join(
+    os.path.dirname(THIS_PATH), "..", "..", "data", "server_locations.json"
+)
+with open(PATH_MACHINES, "r", encoding="utf-8") as infile:
     ALL_LOCATIONS = json.load(infile)
+if os.path.exists(PATH_SERVER_MACHINES):
+    with open(PATH_SERVER_MACHINES, "r", encoding="utf-8") as infile:
+        SERVER_LOCATIONS = json.load(infile)
+else:
+    SERVER_LOCATIONS = {"features": []}
 
 
 def find_machine_in_database(
@@ -89,6 +99,57 @@ def get_next_free_machine_id(
     max_id_pics = max(pic_ids) if len(pic_ids) > 0 else 0
 
     return max([max_id_all, max_id_server, max_id_pics]) + 1
+
+
+def get_nearby_machines(
+    lat: float, lon: float, area: str, radius_m: int = 150
+) -> List[Dict]:
+    """Find machines near a coordinate.
+
+    Args:
+        lat: Latitude of the submitted machine.
+        lon: Longitude of the submitted machine.
+        area: Area of the submitted machine.
+        radius_m: Search radius in meters.
+
+    Returns:
+        Nearby machine summaries sorted by ascending distance.
+    """
+
+    radius_km = radius_m / 1000
+    lat_delta = radius_km / 111
+    lon_delta = radius_km / (111 * max(abs(cos(radians(lat))), 0.01))
+    machines = {
+        machine["properties"]["id"]: machine for machine in ALL_LOCATIONS["features"]
+    }
+    for machine in SERVER_LOCATIONS["features"]:
+        machines[machine["properties"]["id"]] = machine
+
+    nearby = []
+    for machine in machines.values():
+        props = machine["properties"]
+        if props["area"] != area:
+            continue
+        machine_lon, machine_lat = machine["geometry"]["coordinates"]
+        # Michael's trick
+        if not (
+            lat - lat_delta <= machine_lat <= lat + lat_delta
+            and lon - lon_delta <= machine_lon <= lon + lon_delta
+        ):
+            continue
+        distance_m = 1000 * haversine((lat, lon), (machine_lat, machine_lon))
+        if distance_m < radius_m:
+            nearby.append(
+                {
+                    "id": props["id"],
+                    "name": props["name"],
+                    "address": props["address"],
+                    "area": props["area"],
+                    "machine_status": props.get("machine_status", "available"),
+                    "distance_m": round(distance_m),
+                }
+            )
+    return sorted(nearby, key=lambda machine: machine["distance_m"])
 
 
 def verify_remaining_machines(

--- a/data/all_locations.json
+++ b/data/all_locations.json
@@ -108608,7 +108608,7 @@
             },
             "properties": {
                 "name": "Bakonybél",
-                "area": "8427 Hungary",
+                "area": "Hungary",
                 "address": "Bakonybél, Rákóczi tér 22, 8427 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -108692,7 +108692,7 @@
             },
             "properties": {
                 "name": "Zirc",
-                "area": "8420 Hungary",
+                "area": "Hungary",
                 "address": "Zirc, Rákóczi tér 1, 8420 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -109721,7 +109721,7 @@
             },
             "properties": {
                 "name": "Abádszalók",
-                "area": "5241 Hungary",
+                "area": "Hungary",
                 "address": "Abádszalók, 5241 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -109847,7 +109847,7 @@
             },
             "properties": {
                 "name": "Budapest",
-                "area": "1121 Hungary",
+                "area": "Hungary",
                 "address": "Budapest, Hegyhát út 5, 1121 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -109868,7 +109868,7 @@
             },
             "properties": {
                 "name": "Budapest",
-                "area": "1037 Hungary",
+                "area": "Hungary",
                 "address": "Budapest, 1037 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -110078,7 +110078,7 @@
             },
             "properties": {
                 "name": "Zirc",
-                "area": "8420 Hungary",
+                "area": "Hungary",
                 "address": "Zirc, Damjanich u. 19, 8420 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -110351,7 +110351,7 @@
             },
             "properties": {
                 "name": "Zalakomár",
-                "area": "8751 Hungary",
+                "area": "Hungary",
                 "address": "Zalakomár, 8751 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -110477,7 +110477,7 @@
             },
             "properties": {
                 "name": "Balatonszemes",
-                "area": "8636 Hungary",
+                "area": "Hungary",
                 "address": "Balatonszemes, Kikötő u. 1, 8636 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -110687,7 +110687,7 @@
             },
             "properties": {
                 "name": "Oroszlány",
-                "area": "2840 Hungary",
+                "area": "Hungary",
                 "address": "Oroszlány, 2840 Hungary",
                 "status": "unvisited",
                 "external_url": "null",
@@ -110750,7 +110750,7 @@
             },
             "properties": {
                 "name": "Csókakő",
-                "area": "8074 Hungary",
+                "area": "Hungary",
                 "address": "Csókakő, Zrínyi u. 11, 8074 Hungary",
                 "status": "unvisited",
                 "external_url": "null",

--- a/data/server_locations.json
+++ b/data/server_locations.json
@@ -8491,7 +8491,7 @@
             },
             "properties": {
                 "name": "Zalakomár - Kápolnapusztai Bivalyrezervátum",
-                "area": "8751 Hungary",
+                "area": "Hungary",
                 "address": "Zalakomár, 8751 Hungary",
                 "status": "unvisited",
                 "external_url": "null",


### PR DESCRIPTION
- If submitted machine is < 150m to existing machines we show a warning to the user. User can dismiss and submit request anyways
- If the machine title has a >90% fuzzy search similarity to any nearby existing machine, we block the submission of the request and instead offer to open the existing machine view and alter it
- Distance checks are only done to all machines within the same area (for efficiency reasons, otherwise naively 10K haversine distance calculations)
- NewMachine creation form now also has an auto-complete on the area