### PR TITLE
feat: more flexible handling of machine name matches

### DIFF
--- a/PennyMe/NewMachineRequest.swift
+++ b/PennyMe/NewMachineRequest.swift
@@ -133,6 +133,7 @@ struct NewMachineFormView: View {
     @State private var isImagePickerPresented: Bool = false
     @State private var showAlert = false
     @State private var duplicateMachine: NearbyMachine? = nil
+    @State private var similarMachine: NearbyMachine? = nil
     @State private var nearbyMachines: [NearbyMachine] = []
     @State private var nearbyConfirmationPending = false
     @State private var isLoading = false
@@ -276,7 +277,7 @@ struct NewMachineFormView: View {
             if let duplicateMachine = duplicateMachine {
                 warningBackdrop
                 warningBox {
-                    Text("This machine already exists")
+                    Text("A machine with this exact name already exists nearby")
                         .font(.headline)
                     if isExistingMachineBlocked?(duplicateMachine.machineID) == true {
                         Text("You blocked this machine listing.")
@@ -304,6 +305,17 @@ struct NewMachineFormView: View {
                         self.duplicateMachine = nil
                     }) {
                         secondaryButtonLabel("Cancel")
+                    }
+                }
+            } else if let similarMachine = similarMachine {
+                warningBackdrop
+                warningBox {
+                    Text("A similarly named machine '\(similarMachine.name)' already exists. Pick a more distinct name.")
+                        .font(.headline)
+                    Button(action: {
+                        self.similarMachine = nil
+                    }) {
+                        primaryButtonLabel("Change name")
                     }
                 }
             } else if nearbyConfirmationPending {
@@ -395,6 +407,7 @@ struct NewMachineFormView: View {
         DispatchQueue.main.async {
             displayResponse = message
             duplicateMachine = nil
+            similarMachine = nil
             nearbyConfirmationPending = false
             showAlert = true
             isLoading = false
@@ -405,6 +418,17 @@ struct NewMachineFormView: View {
     private func showDuplicateMachine(machine: NearbyMachine) {
         DispatchQueue.main.async {
             duplicateMachine = machine
+            similarMachine = nil
+            nearbyConfirmationPending = false
+            isLoading = false
+        }
+    }
+
+    // Ask for a more distinct title while preserving the form's current input.
+    private func showSimilarMachine(machine: NearbyMachine) {
+        DispatchQueue.main.async {
+            duplicateMachine = nil
+            similarMachine = machine
             nearbyConfirmationPending = false
             isLoading = false
         }
@@ -414,6 +438,7 @@ struct NewMachineFormView: View {
     private func confirmNearbyMachines(machines: [NearbyMachine]) {
         DispatchQueue.main.async {
             duplicateMachine = nil
+            similarMachine = nil
             nearbyMachines = machines
             nearbyConfirmationPending = true
             isLoading = false
@@ -502,6 +527,12 @@ struct NewMachineFormView: View {
                                            let duplicateJSON = json["duplicate_machine"] as? [String: Any],
                                            let duplicateMachine = NearbyMachine(json: duplicateJSON) {
                                             showDuplicateMachine(machine: duplicateMachine)
+                                            return
+                                        }
+                                        if statusCode == 409,
+                                           let similarJSON = json["similar_machine"] as? [String: Any],
+                                           let similarMachine = NearbyMachine(json: similarJSON) {
+                                            showSimilarMachine(machine: similarMachine)
                                             return
                                         }
                                         if statusCode == 409,

--- a/backend/app.py
+++ b/backend/app.py
@@ -43,6 +43,7 @@ from pennyme.slack import (
 )
 from pennyme.utils import (
     find_machine_in_database,
+    find_machine_name_conflict,
     get_nearby_machines,
     setup_locdiffer_logger,
 )
@@ -451,20 +452,41 @@ def create_machine() -> Tuple[Response, int]:
         float(request.args.get("lon_coord")),
         float(request.args.get("lat_coord")),
     )
-    nearby_machines = get_nearby_machines(location[1], location[0], area)
-    for machine in nearby_machines:
-        _, score = fuzzysearch.extract(title, [machine["name"]], limit=1)[0]
-        if score > 90:
-            return (
-                jsonify(
-                    {
-                        "error": "This machine already exists",
-                        "duplicate_machine": {**machine, "title_match_score": score},
-                    }
-                ),
-                409,
-            )
+    name_match_machines = get_nearby_machines(
+        location[1], location[0], area, radius_m=500
+    )
+    conflict_kind, conflict_machine, score = find_machine_name_conflict(
+        title, name_match_machines
+    )
+    if conflict_kind == "exact":
+        return (
+            jsonify(
+                {
+                    "error": "A machine with this exact name already exists nearby",
+                    "duplicate_machine": {
+                        **conflict_machine,
+                        "title_match_score": score,
+                    },
+                }
+            ),
+            409,
+        )
+    if conflict_kind == "similar":
+        return (
+            jsonify(
+                {
+                    "error": f"A similarly named machine '{conflict_machine['name']}' already exists. Pick a more distinct name.",
+                    "similar_machine": {
+                        **conflict_machine,
+                        "title_match_score": score,
+                    },
+                }
+            ),
+            409,
+        )
 
+    # Preserve the generic proximity warning at its existing 150 metre radius.
+    nearby_machines = get_nearby_machines(location[1], location[0], area)
     if request.args.get("ignore_nearby") != "true" and nearby_machines:
         nearby_lines = [
             f"{machine['distance_m']}m: {machine['name']} ({machine['machine_status']})"

--- a/backend/pennyme/utils.py
+++ b/backend/pennyme/utils.py
@@ -4,11 +4,12 @@ import sys
 from contextlib import contextmanager
 from copy import deepcopy
 from math import cos, radians
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 from haversine import haversine
 from loguru import logger
+from thefuzz import process as fuzzysearch
 
 from pennyme.pennycollector import DAY, MONTH, YEAR
 
@@ -150,6 +151,37 @@ def get_nearby_machines(
                 }
             )
     return sorted(nearby, key=lambda machine: machine["distance_m"])
+
+
+def find_machine_name_conflict(
+    title: str, nearby_machines: List[Dict]
+) -> Tuple[Optional[str], Optional[Dict], Optional[int]]:
+    """Find an exact or fuzzy title conflict among nearby machines.
+
+    Exact matches compare lowercased, stripped names and take priority over fuzzy
+    matches. This lets callers present a known duplicate differently from a title
+    that merely needs to be made more distinct.
+
+    Args:
+        title: The proposed machine name.
+        nearby_machines: Machine summaries returned by ``get_nearby_machines``.
+
+    Returns:
+        A tuple of conflict kind (``exact`` or ``similar``), matching machine, and
+        fuzzy score. All values are ``None`` when there is no conflict.
+    """
+
+    normalized_title = title.strip().lower()
+    for machine in nearby_machines:
+        if machine["name"].strip().lower() == normalized_title:
+            return "exact", machine, 100
+
+    for machine in nearby_machines:
+        _, score = fuzzysearch.extract(title, [machine["name"]], limit=1)[0]
+        if score > 90:
+            return "similar", machine, score
+
+    return None, None, None
 
 
 def verify_remaining_machines(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "slack-sdk>=3.39.0",
   "waitress",
   "typer>=0.21.0",
+  "pytest>=9.1.1",
 ]
 
 classifiers = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -270,6 +270,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "isort"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -576,6 +585,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "rembg", extra = ["cpu"] },
     { name = "requests" },
     { name = "ruff" },
@@ -601,6 +611,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "pre-commit" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "rembg", extras = ["cpu"], specifier = ">=2.0.69" },
     { name = "requests" },
     { name = "ruff", specifier = ">=0.14.13" },
@@ -637,6 +648,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -754,6 +774,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
new behavior:
- If the machine name is exactly identical (after doing lowercase and strip) AND it is in a 500m radius, then show "A machine with this exact name already exists nearby". User options: Open machine or Cancel.
- If machine is in a 500m radius AND the name has a fuzzy match score > 90, display a message "A similarly named machine '{name}' already exists. Pick a more distinct name." and then a "Change name" button that allows the user to edit the machine name